### PR TITLE
Patch that adds a "Window" menu for OSX

### DIFF
--- a/src/tomahawkwindow.cpp
+++ b/src/tomahawkwindow.cpp
@@ -21,6 +21,8 @@
 
 #include <QAction>
 #include <QCloseEvent>
+#include <QShowEvent>
+#include <QHideEvent>
 #include <QInputDialog>
 #include <QPixmap>
 #include <QPropertyAnimation>
@@ -263,6 +265,13 @@ TomahawkWindow::setupSignals()
     connect( ui->actionCreate_New_Station, SIGNAL( triggered() ), SLOT( createStation() ));
     connect( ui->actionAboutTomahawk, SIGNAL( triggered() ), SLOT( showAboutTomahawk() ) );
     connect( ui->actionExit, SIGNAL( triggered() ), APP, SLOT( quit() ) );
+#if defined( Q_OS_DARWIN )
+    connect( ui->actionMinimize, SIGNAL( triggered() ), SLOT( minimize() ) );
+    connect( ui->actionZoom, SIGNAL( triggered() ), SLOT( maximize() ) );
+#else
+    ui->menuWindow->clear();
+    ui->menuWindow->menuAction()->setVisible( false );
+#endif
 
     // <SipHandler>
     connect( APP->sipHandler(), SIGNAL( connected() ), SLOT( onSipConnected() ) );
@@ -290,7 +299,6 @@ TomahawkWindow::changeEvent( QEvent* e )
     }
 }
 
-
 void
 TomahawkWindow::closeEvent( QCloseEvent* e )
 {
@@ -306,6 +314,27 @@ TomahawkWindow::closeEvent( QCloseEvent* e )
     e->accept();
 }
 
+void
+TomahawkWindow::showEvent( QShowEvent* e )
+{
+    QMainWindow::showEvent( e );
+
+#if defined( Q_OS_DARWIN )
+    ui->actionMinimize->setDisabled( false );
+    ui->actionZoom->setDisabled( false );
+#endif
+}
+
+void
+TomahawkWindow::hideEvent( QHideEvent* e )
+{
+    QMainWindow::hideEvent( e );
+
+#if defined( Q_OS_DARWIN )
+    ui->actionMinimize->setDisabled( true );
+    ui->actionZoom->setDisabled( true );
+#endif
+}
 
 void
 TomahawkWindow::showSettingsDialog()
@@ -512,4 +541,24 @@ TomahawkWindow::checkForUpdates()
 #ifdef Q_WS_MAC
     Tomahawk::checkForUpdates();
 #endif
+}
+
+void
+TomahawkWindow::minimize()
+{
+    if (isMinimized()) {
+        showNormal();
+    } else {
+        showMinimized();
+    }
+}
+
+void
+TomahawkWindow::maximize()
+{
+    if (isMaximized()) {
+        showNormal();
+    } else {
+        showMaximized();
+    }
 }

--- a/src/tomahawkwindow.h
+++ b/src/tomahawkwindow.h
@@ -54,6 +54,8 @@ public:
 protected:
     void changeEvent( QEvent* e );
     void closeEvent( QCloseEvent* e );
+    void showEvent( QShowEvent* e );
+    void hideEvent( QHideEvent* e );
 
 public slots:
     void createAutomaticPlaylist();
@@ -78,6 +80,9 @@ private slots:
     
     void showAboutTomahawk();
     void checkForUpdates();
+
+    void minimize();
+    void maximize();
 
 private:
     void loadSettings();

--- a/src/tomahawkwindow.ui
+++ b/src/tomahawkwindow.ui
@@ -72,6 +72,13 @@
     <addaction name="actionToggleConnect"/>
     <addaction name="separator"/>
    </widget>
+   <widget class="QMenu" name="menuWindow">
+    <property name="title">
+     <string>&amp;Window</string>
+    </property>
+    <addaction name="actionMinimize"/>
+    <addaction name="actionZoom"/>
+   </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
      <string>&amp;Help</string>
@@ -82,6 +89,7 @@
    <addaction name="menuPlaylist"/>
    <addaction name="menuNetwork"/>
    <addaction name="menuSettings"/>
+   <addaction name="menuWindow"/>
    <addaction name="menu_Help"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
@@ -155,6 +163,22 @@
   <action name="actionHideOfflineSources">
    <property name="text">
     <string>Hide Offline Sources</string>
+   </property>
+  </action>
+  <action name="actionMinimize">
+   <property name="text">
+    <string>Minimize</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+M</string>
+   </property>
+  </action>
+  <action name="actionZoom">
+   <property name="text">
+    <string>Zoom</string>
+   </property>
+   <property name="shortcut">
+    <string>Meta+Ctrl+Z</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Hi! I don't have an Ubuntu desktop handy, so I just implemented this "Window" menu for OSX. 
