### PR TITLE
Proposed Fix for bug TWK-221

### DIFF
--- a/thirdparty/libportfwd/src/portfwd.cpp
+++ b/thirdparty/libportfwd/src/portfwd.cpp
@@ -82,10 +82,22 @@ Portfwd::init(unsigned int timeout)
            free (descXML); descXML = 0;
            GetUPNPUrls (urls, data, dev->descURL);
        }
+       else
+       {
+           printf("couldn't get the UPnP device description XML (descXML is null)");
+           freeUPNPDevlist(devlist);
+           return false;
+       }
        // get lan IP:
        char lanaddr[16];
-       int i;
-       i = UPNP_GetValidIGD(devlist, urls, data, (char*)&lanaddr, 16);
+       int idg_was_found = UPNP_GetValidIGD(devlist, urls, data, (char*)&lanaddr, 16);
+       printf("UPNP_GetValidIGD returned %d", idg_was_found);
+       if (!idg_was_found)
+       {
+           printf("NO IGD was found (function UPNP_GetValidIGD())");
+           freeUPNPDevlist(devlist);
+           return false;
+       }
        m_lanip = std::string(lanaddr);
        
        freeUPNPDevlist(devlist);
@@ -98,6 +110,7 @@ Portfwd::init(unsigned int timeout)
 void
 Portfwd::get_status()
 {
+    Q_ASSERT(urls->controlURL_CIF != NULL);
     // get connection speed
     UPNP_GetLinkLayerMaxBitRates(
         urls->controlURL_CIF, data->CIF.servicetype, &m_downbps, &m_upbps);


### PR DESCRIPTION
Fix for bug TWK-221, Segfault at start due to UPnP device description XML download fail.

Further work
FIXME: Figure out how to make it use the proper port (81 eg. instaed of standard 80)
       maybe it's upnpDiscover() that's not working correcly
