### PR TITLE
"xesam:artist" MPRIS2 type change

### DIFF
--- a/src/libtomahawk/infosystem/infoplugins/unix/mprisplugin.cpp
+++ b/src/libtomahawk/infosystem/infoplugins/unix/mprisplugin.cpp
@@ -257,7 +257,7 @@ MprisPlugin::metadata() const
         metadataMap.insert( "mpris:trackid", QString( "/track/" ) + track->id().replace( "-", "" ) );
         metadataMap.insert( "mpris:length", track->duration() );
         metadataMap.insert( "xesam:album", track->album()->name() );
-        metadataMap.insert( "xesam:artist", track->artist()->name() );
+        metadataMap.insert( "xesam:artist", QStringList( track->artist()->name() ) );
         metadataMap.insert( "xesam:title", track->track() );
 
         // Only return art if tempfile exists, and if its name contains the same "artist_album_tomahawk_cover.png"


### PR DESCRIPTION
Hi,

Please take a look at my pull request.

Changed "xesam:artist" property in MPRIS2 infosystem plugin to a list of strings since this is what it should be according to the [specification](http://xmms2.org/wiki/MPRIS_Metadata#xesam:artist).
MPRIS2 receivers (like [covergloobus](https://launchpad.net/covergloobus)) treat the incoming property as a list and this makes the output crazy.

Tested this change with my own player plugin for covergloobus and it works as expected.
