### PR TITLE
added "Send this report" and "Don't send" buttons

### DIFF
--- a/src/breakpad/CrashReporter/CrashReporter.cpp
+++ b/src/breakpad/CrashReporter/CrashReporter.cpp
@@ -36,7 +36,6 @@ CrashReporter::CrashReporter( const QStringList& args )
     setWindowIcon( QIcon( RESPATH "icons/tomahawk-icon-128x128.png" ) );
 
     ui.setupUi( this );
-
     ui.logoLabel->setPixmap( QPixmap( RESPATH "icons/tomahawk-icon-128x128.png" ).scaled( QSize( 55, 55 ), Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
     ui.progressBar->setRange( 0, 100 );
     ui.progressBar->setValue( 0 );
@@ -51,20 +50,11 @@ CrashReporter::CrashReporter( const QStringList& args )
     ui.progressLabel->setIndent( 3 );
   #else
     ui.vboxLayout->setSpacing( 16 );
+    ui.hboxLayout1->setSpacing( 16 );
     ui.progressBar->setTextVisible( false );
     ui.progressLabel->setIndent( 1 );
     ui.bottomLabel->setDisabled( true );
     ui.bottomLabel->setIndent( 1 );
-
-    // adjust the spacer since we adjusted the spacing above
-    for ( int x = 0; x < ui.vboxLayout->count(); ++x )
-    {
-        if ( QSpacerItem* spacer = ui.vboxLayout->itemAt( x )->spacerItem() )
-        {
-            spacer->changeSize( 6, 2, QSizePolicy::Minimum, QSizePolicy::Fixed );
-            break;
-        }
-    }
   #endif //Q_WS_MAC
 
     m_http = new QHttp( "oops.tomahawk-player.org", 80, this );
@@ -78,7 +68,18 @@ CrashReporter::CrashReporter( const QStringList& args )
 
     setFixedSize( sizeHint() );
 
-    QTimer::singleShot( 0, this, SLOT( send() ) );
+    //hide until "send report" has been clicked
+    ui.progressBar->setVisible( false );
+    ui.button->setVisible( false );
+    ui.progressLabel->setVisible( false );
+    connect( ui.sendButton, SIGNAL( clicked() ), SLOT( onSendButton() ));
+
+
+}
+
+CrashReporter::~CrashReporter()
+{
+    delete m_http;
 }
 
 
@@ -183,4 +184,15 @@ CrashReporter::onFail( int error, const QString& errorString )
     ui.button->setText( tr( "Close" ) );
     ui.progressLabel->setText( tr( "Failed to send crash info." ) );
     qDebug() << "Error:" << error << errorString;
+}
+
+void
+CrashReporter::onSendButton()
+{
+    ui.progressBar->setVisible( true );
+    ui.button->setVisible( true );
+    ui.progressLabel->setVisible( true );
+    ui.sendButton->setEnabled( false );
+    ui.dontSendButton->setEnabled( false );
+    QTimer::singleShot( 0, this, SLOT( send() ) );
 }

--- a/src/breakpad/CrashReporter/CrashReporter.h
+++ b/src/breakpad/CrashReporter/CrashReporter.h
@@ -31,6 +31,7 @@ class CrashReporter : public QDialog
 
 public:
     CrashReporter( const QStringList& argv );
+    ~CrashReporter( );
 
 private:
     Ui::CrashReporter ui;
@@ -47,6 +48,7 @@ private slots:
     void onDone();
     void onProgress( int done, int total );
     void onFail( int error, const QString& errorString );
+    void onSendButton();
 };
 
 #endif // CRASHREPORTER_H

--- a/src/breakpad/CrashReporter/CrashReporter.ui
+++ b/src/breakpad/CrashReporter/CrashReporter.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>196</height>
+    <height>246</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,7 +33,7 @@
     <number>9</number>
    </property>
    <item>
-    <layout class="QHBoxLayout">
+    <layout class="QHBoxLayout" name="hboxLayout">
      <property name="spacing">
       <number>12</number>
      </property>
@@ -77,7 +77,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>&lt;p&gt;&lt;b&gt;Sorry!&lt;/b&gt;&amp;nbsp;Tomahawk crashed. Information about the crash is now being sent to Tomahawk HQ so that we can fix the bug.&lt;/p&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Sorry!&lt;/span&gt; Tomahawk crashed. Please tell us about it! Tomahawk has created an error report for you that can help improve the stability in the future. You can now send the this report directly to the Tomahawk developers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textFormat">
         <enum>Qt::RichText</enum>
@@ -106,23 +106,41 @@
     </layout>
    </item>
    <item>
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <layout class="QHBoxLayout" name="hboxLayout1">
+     <property name="spacing">
+      <number>-1</number>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>16</height>
-      </size>
-     </property>
-    </spacer>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="sendButton">
+       <property name="text">
+        <string>Send this report</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="dontSendButton">
+       <property name="text">
+        <string>Don't send</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout">
+    <layout class="QVBoxLayout" name="vboxLayout1">
      <property name="spacing">
       <number>0</number>
      </property>
@@ -210,12 +228,28 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>424</x>
-     <y>154</y>
+     <x>426</x>
+     <y>203</y>
     </hint>
     <hint type="destinationlabel">
      <x>247</x>
      <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>dontSendButton</sender>
+   <signal>clicked()</signal>
+   <receiver>CrashReporter</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>380</x>
+     <y>117</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>218</x>
+     <y>122</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Most users probably do not disable crash reporting. 
If these users don't want to send the report or don't know of that feature they currently don't have a fair chance to abort the operation.

Example:

With a size of about 0.5 MB and 1 Mbit/s upload speed, a user only has 4 seconds to hit "Abort".

Adding two simple buttons will give them a chance to abort if they do not want to send their crash report.
