### PR TITLE
Mpris2 fixes

### DIFF
--- a/src/libtomahawk/infosystem/infoplugins/unix/MprisPlugin.cpp
+++ b/src/libtomahawk/infosystem/infoplugins/unix/MprisPlugin.cpp
@@ -332,14 +332,14 @@ MprisPlugin::setShuffle( bool value )
 double
 MprisPlugin::volume() const
 {
-    return AudioEngine::instance()->volume();
+    return static_cast<double>(AudioEngine::instance()->volume()) / 100.0;
 }
 
 
 void
 MprisPlugin::setVolume( double value )
 {
-    AudioEngine::instance()->setVolume( value );
+    AudioEngine::instance()->setVolume( value * 100 );
 }
 
 


### PR DESCRIPTION
Fix some of the more egregious typing errors in the MPRIS2 interface.

PropertiesChanged is still not always emitted when it should be.
