### PR TITLE
Fix key event handling in SourceTreeView

### DIFF
--- a/src/TomahawkWindow.cpp
+++ b/src/TomahawkWindow.cpp
@@ -245,7 +245,7 @@ TomahawkWindow::setupSideBar()
     m_sidebar->setOrientation( Qt::Vertical );
     m_sidebar->setChildrenCollapsible( false );
 
-    m_sourcetree = new SourceTreeView();
+    m_sourcetree = new SourceTreeView( this );
     JobStatusView* jobsView = new JobStatusView( m_sidebar );
     m_jobsModel = new JobStatusModel( jobsView );
     jobsView->setModel( m_jobsModel );

--- a/src/sourcetree/SourceTreeView.cpp
+++ b/src/sourcetree/SourceTreeView.cpp
@@ -688,7 +688,13 @@ SourceTreeView::keyPressEvent( QKeyEvent *event )
                 deletePlaylist( idx );
             }
         }
+        event->accept();
     }
+    else
+    {
+        event->ignore();
+    }
+    QTreeView::keyPressEvent( event );
 }
 
 


### PR DESCRIPTION
Correctly propagate multimedia key events to mainwindow
