### PR TITLE
Workaround to force QtCurve to not draw branching primitives in SourceTreeView

### DIFF
--- a/src/sourcetree/SourceTreeView.cpp
+++ b/src/sourcetree/SourceTreeView.cpp
@@ -838,6 +838,13 @@ SourceTreeView::drawRow( QPainter* painter, const QStyleOptionViewItem& option, 
     QTreeView::drawRow( painter, option, index );
 }
 
+void
+SourceTreeView::drawBranches( QPainter *painter, const QRect &rect, const QModelIndex &index ) const
+{
+    if( !QString( qApp->style()->metaObject()->className() ).toLower().contains( "qtcurve" ) )
+        QTreeView::drawBranches( painter, rect, index );
+}
+
 
 template< typename T > T*
 SourceTreeView::itemFromIndex( const QModelIndex& index ) const

--- a/src/sourcetree/SourceTreeView.h
+++ b/src/sourcetree/SourceTreeView.h
@@ -89,6 +89,7 @@ private slots:
 
 protected:
     void drawRow( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const;
+    void drawBranches( QPainter *painter, const QRect &rect, const QModelIndex &index ) const;
 
     virtual void paintEvent( QPaintEvent* event );
 


### PR DESCRIPTION
Just a one-liner to override drawBranches and block QTreeView::drawBranches from doing its thing under QtCurve.
