### PR TITLE
Fixes cmake file for finding CLucene libraries on systems supporting mul...

### DIFF
--- a/CMakeModules/FindCLucene.cmake
+++ b/CMakeModules/FindCLucene.cmake
@@ -41,6 +41,7 @@ SET(TRIAL_LIBRARY_PATHS
   /sw/lib${LIB_SUFFIX}
   /usr/pkg/lib${LIB_SUFFIX}
   /usr/lib64
+  /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
   )
 SET(TRIAL_INCLUDE_PATHS
   $ENV{CLUCENE_HOME}/include


### PR DESCRIPTION
...tiarch

Debian and Ubuntu switching to support multiarch, libraries gets installed
under /usr/lib/{multiarch-triplet}.
ie: /usr/lib/x86_64-linux-gnu .

See http://public.kitware.com/Bug/view.php?id=12037 for a like-wise bug
with good details.
