### PR TITLE
show resolver icon in accounts widget for external resolvers

### DIFF
--- a/src/libtomahawk/accounts/AccountDelegate.cpp
+++ b/src/libtomahawk/accounts/AccountDelegate.cpp
@@ -171,7 +171,7 @@ AccountDelegate::paint ( QPainter* painter, const QStyleOptionViewItem& option, 
     QPixmap p = index.data( Qt::DecorationRole ).value< QPixmap >();
     QRect pixmapRect( leftEdge + PADDING, center - ICONSIZE/2, ICONSIZE, ICONSIZE );
     if ( p.isNull() ) // default image... TODO
-        p = TomahawkUtils::defaultPixmap( TomahawkUtils::SipPluginOnline, TomahawkUtils::Original, pixmapRect.size() );
+        p = TomahawkUtils::defaultPixmap( TomahawkUtils::DefaultResolver, TomahawkUtils::Original, pixmapRect.size() );
     else
         p = p.scaled( pixmapRect.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation );
 

--- a/src/libtomahawk/accounts/ResolverAccount.cpp
+++ b/src/libtomahawk/accounts/ResolverAccount.cpp
@@ -232,6 +232,11 @@ ResolverAccount::resolverChanged()
     emit connectionStateChanged( connectionState() );
 }
 
+QPixmap
+ResolverAccount::icon() const
+{
+    return m_resolver.data()->icon();
+}
 
 /// AtticaResolverAccount
 

--- a/src/libtomahawk/accounts/ResolverAccount.h
+++ b/src/libtomahawk/accounts/ResolverAccount.h
@@ -77,8 +77,9 @@ public:
 
     QString path() const;
 
+    virtual QPixmap icon() const;
+
     // Not relevant
-    virtual QPixmap icon() const { return QPixmap(); }
     virtual SipPlugin* sipPlugin() { return 0; }
     virtual Tomahawk::InfoSystem::InfoPluginPtr infoPlugin() { return Tomahawk::InfoSystem::InfoPluginPtr(); }
     virtual QWidget* aclWidget() { return 0; }


### PR DESCRIPTION
Works for resolvers with and without icon.

![Bildschirmfoto2](https://f.cloud.github.com/assets/1190429/38278/7caae942-54dd-11e2-99d7-d2621403a065.png)
