### PR TITLE
receive icon directly from resolvers

### DIFF
--- a/src/libtomahawk/resolvers/QtScriptResolver.cpp
+++ b/src/libtomahawk/resolvers/QtScriptResolver.cpp
@@ -326,15 +326,21 @@ QtScriptResolver::init()
     m_name    = m.value( "name" ).toString();
     m_weight  = m.value( "weight", 0 ).toUInt();
     m_timeout = m.value( "timeout", 25 ).toUInt() * 1000;
-    QString iconPath = QFileInfo( filePath() ).path() + "/" + m.value( "icon" ).toString();
-    int success = m_icon.load( iconPath );
+    bool compressed = m.value( "compressed", "false" ).toString() == "true";
+
+    QByteArray icoData = m.value( "icon" ).toByteArray();
+    if( compressed )
+        icoData = qUncompress( QByteArray::fromBase64( icoData ) );
+    else
+        icoData = QByteArray::fromBase64( icoData );
+    bool success = m_icon.loadFromData( icoData );
 
     // load config widget and apply settings
     loadUi();
     QVariantMap config = resolverUserConfig();
     fillDataInWidgets( config );
 
-    qDebug() << "JS" << filePath() << "READY," << "name" << m_name << "weight" << m_weight << "timeout" << m_timeout << "icon" << iconPath << "icon found" << success;
+    qDebug() << "JS" << filePath() << "READY," << "name" << m_name << "weight" << m_weight << "timeout" << m_timeout << "icon found" << success;
 
     m_ready = true;
 }

--- a/src/libtomahawk/resolvers/ScriptResolver.cpp
+++ b/src/libtomahawk/resolvers/ScriptResolver.cpp
@@ -376,10 +376,16 @@ ScriptResolver::doSetup( const QVariantMap& m )
     m_name    = m.value( "name" ).toString();
     m_weight  = m.value( "weight", 0 ).toUInt();
     m_timeout = m.value( "timeout", 5 ).toUInt() * 1000;
-    QString iconPath = QFileInfo( filePath() ).path() + "/" + m.value( "icon" ).toString();
-    int success = m_icon.load( iconPath );
+    bool compressed = m.value( "compressed", "false" ).toString() == "true";
 
-    qDebug() << "SCRIPT" << filePath() << "READY," << "name" << m_name << "weight" << m_weight << "timeout" << m_timeout << "icon" << iconPath << "icon found" << success;
+    QByteArray icoData = m.value( "icon" ).toByteArray();
+    if( compressed )
+        icoData = qUncompress( QByteArray::fromBase64( icoData ) );
+    else
+        icoData = QByteArray::fromBase64( icoData );
+    bool success = m_icon.loadFromData( icoData );
+
+    qDebug() << "SCRIPT" << filePath() << "READY," << "name" << m_name << "weight" << m_weight << "timeout" << m_timeout << "icon found" << success;
 
     m_ready = true;
     m_configSent = false;


### PR DESCRIPTION
Dont let external resolvers send a (probably faulty) path to an image
file, but receive the image itself directly. This is consistent with
the way the config _msgtype works, so comression is supported, too.

I know this breaks the way current resolvers send their icons, but afaik the only resolvers that used this api were DAAP and Google Music resolvers, which are both maintained by me...
