### PR TITLE
Support Opening of ShareMyPlaylists (Spotify-) URLs

### DIFF
--- a/src/libtomahawk/utils/SpotifyParser.cpp
+++ b/src/libtomahawk/utils/SpotifyParser.cpp
@@ -90,7 +90,7 @@ SpotifyParser::lookupUrl( const QString& rawLink )
     QString smpPrefix = "spotify:app:sharemyplaylists:subscribe:playlist:";
     if ( link.startsWith( smpPrefix ) )
     {
-	link = QUrl::fromPercentEncoding(link.mid(smpPrefix.size()).toUtf8());
+        link = QUrl::fromPercentEncoding(link.mid(smpPrefix.size()).toUtf8());
     }
     // TODO: Ignoring search and user querys atm
     // (spotify:(?:(?:artist|album|track|user:[^:]+:playlist):[a-zA-Z0-9]+|user:[^:]+|search:(?:[-\w$\.+!*'(),<>:\s]+|%[a-fA-F0-9\s]{2})+))


### PR DESCRIPTION
This should reeanble dragging the "Play Now" button on sharemyplaylists.com to Tomahawk.

(Works even with the "Subscribe" button.)
