### PR TITLE
Allow specifying songs in playlist creation URL

### DIFF
--- a/src/libtomahawk/GlobalActionManager.h
+++ b/src/libtomahawk/GlobalActionManager.h
@@ -105,6 +105,7 @@ private:
 
     /// handle opening of urls
 #ifndef ENABLE_HEADLESS
+    bool handleNewPlaylistCommand( const QUrl& url );
     bool handlePlaylistCommand( const QUrl& url );
     bool handleViewCommand( const QUrl& url );
     bool handleStationCommand( const QUrl& url );


### PR DESCRIPTION
Example usage:

`tomahawk 'tomahawk://playlist/new/?title=Awesome&track_0_artist=Bloc+Party&track_0_title=Flux&track_1_artist=Vampire+Weekend&track_1_title=A+Punk'`
