### PR TITLE
As stated in --help the URL should always be the last argument

### DIFF
--- a/src/TomahawkApp.cpp
+++ b/src/TomahawkApp.cpp
@@ -735,8 +735,8 @@ TomahawkApp::instanceStarted( KDSingleApplicationGuard::Instance instance )
         return;
     }
 
-    QString arg1 = arguments[ 1 ];
-    if ( loadUrl( arg1 ) )
+    QString lastArg = arguments[ arguments.size() - 1 ];
+    if ( loadUrl( lastArg ) )
     {
         activate();
         return;


### PR DESCRIPTION
If you use 'tomahawk --verbose tomahawk://foo', '--verbose' is treated as the URL that should be opened though --help states that the URL should be the last argument.
