### PR TITLE
All album cover should have a maximum size of 128px in dbus notifications

### DIFF
--- a/src/infoplugins/linux/fdonotify/ImageConverter.cpp
+++ b/src/infoplugins/linux/fdonotify/ImageConverter.cpp
@@ -70,6 +70,12 @@ QVariant variantForImage(const QImage &_image)
 	qDBusRegisterMetaType<SpecImage>();
 
 	QImage image = _image.convertToFormat(QImage::Format_ARGB32);
+  // Scale image to a maximum size of 128px
+  if (image.width() > image.height()) {
+    image = image.scaledToWidth(128);
+  } else {
+    image = image.scaledToHeight(128);
+  }
 
 	int rowStride = image.width() * 4;
 


### PR DESCRIPTION
They look better if they aren't that large and they consume less memory when passing to D-Bus.

As a sideeffect the time the window manager in https://bugs.tomahawk-player.org/browse/TWK-1243 blocks is significantly reduced (10-20s to ~1s)
