### PR TITLE
Add markup to the first notification line to overcome problems with KNotify.

### DIFF
--- a/src/infoplugins/linux/fdonotify/FdoNotifyPlugin.cpp
+++ b/src/infoplugins/linux/fdonotify/FdoNotifyPlugin.cpp
@@ -197,6 +197,9 @@ FdoNotifyPlugin::nowPlaying( const QVariant& input )
                         .arg( Qt::escape( hash[ "artist" ] ) )
                         .arg( album )
                         .arg( QString( "\n<i>%1</i>" ).arg( tr( "by", "preposition to link track and artist" ) ) );
+
+        // Dirty hack(TM) so that KNotify/QLabel recognizes the message as Rich Text
+        messageText = QString( "<i></i>%1" ).arg( messageText );
     }
     else
     {


### PR DESCRIPTION
Add an invisible `<i></i>` tag to the first line to cheat on Qt's rich text heuristic.

(I do not like doing this commit, but at the moment this seems the only solution to get a broad support for styled notification (should now work at least with Gnome 3, XFCE, awesome and KDE 4))
