### PR TITLE
Do not double add existing spotify playlists

### DIFF
--- a/src/libtomahawk/accounts/spotify/SpotifyAccount.cpp
+++ b/src/libtomahawk/accounts/spotify/SpotifyAccount.cpp
@@ -1396,6 +1396,18 @@ SpotifyAccount::sendMessage( const QVariantMap &m, QObject* obj, const QString& 
     return qid;
 }
 
+bool
+SpotifyAccount::hasPlaylist(const QString& plId)
+{
+    return m_updaters.contains( plId );
+}
+
+Tomahawk::playlist_ptr
+SpotifyAccount::playlistForURI(const QString& plId)
+{
+    return m_updaters[ plId ]->playlist();
+}
+
 
 void
 SpotifyAccount::registerUpdaterForPlaylist( const QString& plId, SpotifyPlaylistUpdater* updater )

--- a/src/libtomahawk/accounts/spotify/SpotifyAccount.h
+++ b/src/libtomahawk/accounts/spotify/SpotifyAccount.h
@@ -103,7 +103,8 @@ public:
     virtual SipPlugin* sipPlugin() { return 0; }
     virtual bool preventEnabling() const { return m_preventEnabling; }
 
-
+    bool hasPlaylist( const QString& plId );
+    Tomahawk::playlist_ptr playlistForURI( const QString& plId );
     void registerUpdaterForPlaylist( const QString& plId, SpotifyPlaylistUpdater* updater );
     void registerPlaylistInfo( const QString& name, const QString& plid, const QString &revid, const bool sync, const bool subscribed , const bool owner = false);
     void registerPlaylistInfo( SpotifyPlaylistInfo* info );

--- a/src/libtomahawk/utils/SpotifyParser.cpp
+++ b/src/libtomahawk/utils/SpotifyParser.cpp
@@ -401,14 +401,23 @@ SpotifyParser::checkBrowseFinished()
         if ( m_createNewPlaylist && !m_tracks.isEmpty() )
         {
             QString spotifyUsername;
+            bool spotifyAccountLoggedIn = Accounts::SpotifyAccount::instance() && Accounts::SpotifyAccount::instance()->loggedIn();
 
-            if ( Accounts::SpotifyAccount::instance() && Accounts::SpotifyAccount::instance()->loggedIn() )
+            if ( spotifyAccountLoggedIn )
             {
                 QVariantHash creds = Accounts::SpotifyAccount::instance()->credentials();
                 spotifyUsername = creds.value( "username" ).toString();
             }
 
-            m_playlist = Playlist::create( SourceList::instance()->getLocal(),
+            if ( spotifyAccountLoggedIn &&  Accounts::SpotifyAccount::instance()->hasPlaylist( m_browseUri ) )
+            {
+                // The playlist is already registered with Tomahawk, so just open it instead of adding another instance.
+                m_playlist = Accounts::SpotifyAccount::instance()->playlistForURI( m_browseUri );
+                playlistCreated();
+            }
+            else
+            {
+                m_playlist = Playlist::create( SourceList::instance()->getLocal(),
                                        uuid(),
                                        m_title,
                                        m_info,
@@ -416,29 +425,30 @@ SpotifyParser::checkBrowseFinished()
                                        false,
                                        m_tracks );
 
-            connect( m_playlist.data(), SIGNAL( revisionLoaded( Tomahawk::PlaylistRevision ) ), this, SLOT( playlistCreated() ) );
+                connect( m_playlist.data(), SIGNAL( revisionLoaded( Tomahawk::PlaylistRevision ) ), this, SLOT( playlistCreated() ) );
 
-            if ( Accounts::SpotifyAccount::instance() && Accounts::SpotifyAccount::instance()->loggedIn() )
-            {
-                SpotifyPlaylistUpdater* updater = new SpotifyPlaylistUpdater(
-                                                    Accounts::SpotifyAccount::instance(), m_playlist->currentrevision(), m_browseUri, m_playlist );
+                if ( spotifyAccountLoggedIn )
+                {
+                    SpotifyPlaylistUpdater* updater = new SpotifyPlaylistUpdater(
+                                                        Accounts::SpotifyAccount::instance(), m_playlist->currentrevision(), m_browseUri, m_playlist );
 
 
-                // If the user isnt dropping a playlist the he owns, its subscribeable
-                if ( !m_browseUri.contains( spotifyUsername ) )
-                    updater->setCanSubscribe( true );
-                else
-                    updater->setOwner( true );
+                    // If the user isnt dropping a playlist the he owns, its subscribeable
+                    if ( !m_browseUri.contains( spotifyUsername ) )
+                        updater->setCanSubscribe( true );
+                    else
+                        updater->setOwner( true );
 
-                updater->setCollaborative( m_collaborative );
-                updater->setSubscribers( m_subscribers );
-                // Just register the infos
-                Accounts::SpotifyAccount::instance()->registerPlaylistInfo( m_title, m_browseUri, m_browseUri, false, false, updater->owner() );
-                Accounts::SpotifyAccount::instance()->registerUpdaterForPlaylist( m_browseUri, updater );
-                // On default, set the playlist as subscribed
-                if( !updater->owner() )
-                    Accounts::SpotifyAccount::instance()->setSubscribedForPlaylist( m_playlist, true );
+                    updater->setCollaborative( m_collaborative );
+                    updater->setSubscribers( m_subscribers );
+                    // Just register the infos
+                    Accounts::SpotifyAccount::instance()->registerPlaylistInfo( m_title, m_browseUri, m_browseUri, false, false, updater->owner() );
+                    Accounts::SpotifyAccount::instance()->registerUpdaterForPlaylist( m_browseUri, updater );
+                    // On default, set the playlist as subscribed
+                    if( !updater->owner() )
+                        Accounts::SpotifyAccount::instance()->setSubscribedForPlaylist( m_playlist, true );
 
+                }
             }
             return;
         }


### PR DESCRIPTION
If a Spotify playlist is already loaded in Tomahawk, do not add it twice, just open the existing one.
