### PR TITLE
Add qjson include dir

### DIFF
--- a/tests/tomahawk_add_test.cmake
+++ b/tests/tomahawk_add_test.cmake
@@ -1,5 +1,5 @@
 macro(tomahawk_add_test test_class)
-    include_directories(${QT_INCLUDES} "${PROJECT_SOURCE_DIR}/src" ${CMAKE_CURRENT_BINARY_DIR})
+    include_directories(${QT_INCLUDES} "${PROJECT_SOURCE_DIR}/src" ${CMAKE_CURRENT_BINARY_DIR} ${QJSON_INCLUDE_DIR})
 
     set(TOMAHAWK_TEST_CLASS ${test_class})
     set(TOMAHAWK_TEST_TARGET ${TOMAHAWK_TEST_CLASS}Test)


### PR DESCRIPTION
Build was failing on my system because qjson is not installed in /usr/include. Adding its include dir fixes the build.
