### PR TITLE
listen to media key events of gnome settings daemon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(WITH_CRASHREPORTER "Build with CrashReporter" ON)
 option(WITH_BINARY_ATTICA "Enable support for downloading binary resolvers automatically" ON)
 option(LEGACY_KDE_INTEGRATION "Install tomahawk.protocol file, deprecated since 4.6.0" OFF)
 OPTION(WITH_UPOWER "Build with support for UPower events" OFF)
+OPTION(WITH_GNOMESHORTCUTHANDLER "Build with shortcut handler for GNOME" OFF)
 
 IF( CMAKE_SYSTEM_PROCESSOR MATCHES "arm" )
     message(STATUS "Build of breakpad library disabled on this platform.")
@@ -189,7 +190,9 @@ endif()
 
 IF( UNIX AND NOT APPLE AND QT_QTDBUS_FOUND )
     SET( WITH_UPOWER ON )
+    SET( WITH_GNOMESHORTCUTHANDLER ON )
 ENDIF( UNIX AND NOT APPLE AND QT_QTDBUS_FOUND  )
+
 
 macro_optional_find_package(Phonon 4.5.0)
 macro_log_feature(PHONON_FOUND "Phonon" "The Phonon multimedia library" "http://phonon.kde.org" TRUE "" "")

--- a/src/tomahawk/CMakeLists.txt
+++ b/src/tomahawk/CMakeLists.txt
@@ -27,6 +27,11 @@ SET( tomahawkSources ${tomahawkSources}
      main.cpp
 )
 
+IF( WITH_GNOMESHORTCUTHANDLER )
+    SET( tomahawkSources ${tomahawkSources} GnomeShortcutHandler.cpp )
+    qt4_add_dbus_interface(tomahawkSources GnomeSettingsDaemonMediaKeys.xml GnomeSettingsDaemonMediaKeysProxy)
+ENDIF( WITH_GNOMESHORTCUTHANDLER )
+
 IF(LIBLASTFM_FOUND)
     SET(tomahawkSources ${tomahawkSources}
         Scrobbler.cpp

--- a/src/tomahawk/Config.h.in
+++ b/src/tomahawk/Config.h.in
@@ -19,6 +19,7 @@
 #cmakedefine WITH_BINARY_ATTICA
 #cmakedefine WITH_QtSparkle
 #cmakedefine WITH_UPOWER
+#cmakedefine WITH_GNOMESHORTCUTHANDLER
 
 
 #cmakedefine LIBLASTFM_FOUND

--- a/src/tomahawk/GnomeSettingsDaemonMediaKeys.xml
+++ b/src/tomahawk/GnomeSettingsDaemonMediaKeys.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.gnome.SettingsDaemon.MediaKeys">
+    <method name="ReleaseMediaPlayerKeys">
+      <arg name="application" type="s" direction="in"/>
+    </method>
+    <method name="GrabMediaPlayerKeys">
+      <arg name="application" type="s" direction="in"/>
+      <arg name="time" type="u" direction="in"/>
+    </method>
+    <signal name="MediaPlayerKeyPressed">
+      <arg type="s"/>
+      <arg type="s"/>
+    </signal>
+  </interface>
+</node>

--- a/src/tomahawk/GnomeShortcutHandler.cpp
+++ b/src/tomahawk/GnomeShortcutHandler.cpp
@@ -1,0 +1,102 @@
+/* === This file is part of Tomahawk Player - <http://tomahawk-player.org> ===
+ *
+ *   Copyright 2013, Florian Richter <mail@f1ori.de>
+ *
+ *   Tomahawk is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Tomahawk is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Tomahawk. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// implement listen on media keys events provided by the gnome settings daemon
+// as documented here:
+// https://github.com/GNOME/gnome-settings-daemon/blob/master/plugins/media-keys/README.media-keys-API
+
+#include "GnomeShortcutHandler.h"
+#include "utils/Logger.h"
+
+
+# include <QtDBus>
+
+#include <QAction>
+
+using namespace Tomahawk;
+
+const char* GnomeShortcutHandler::kGsdService = "org.gnome.SettingsDaemon";
+const char* GnomeShortcutHandler::kGsdPath = "/org/gnome/SettingsDaemon/MediaKeys";
+const char* GnomeShortcutHandler::kGsdInterface = "org.gnome.SettingsDaemon.MediaKeys";
+
+
+GnomeShortcutHandler::GnomeShortcutHandler(QObject *parent) :
+    Tomahawk::ShortcutHandler(parent),
+    interface_(NULL)
+{
+
+}
+
+bool GnomeShortcutHandler::DoRegister() {
+    tLog(LOGVERBOSE) << "registering for gnome media keys";
+
+    // Check if the GSD service is available
+    if (!QDBusConnection::sessionBus().interface()->isServiceRegistered(kGsdService)) {
+        tLog(LOGVERBOSE) << "gnome settings daemon not registered";
+        return false;
+    }
+
+    if (!interface_) {
+        interface_ = new org::gnome::SettingsDaemon::MediaKeys(
+            kGsdService, kGsdPath, QDBusConnection::sessionBus(), this->parent());
+    }
+
+    QDBusPendingReply<> reply = interface_->GrabMediaPlayerKeys(
+            QCoreApplication::applicationName(), 0);
+
+    QDBusPendingCallWatcher* watcher = new QDBusPendingCallWatcher(reply, this);
+    connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
+               this, SLOT(RegisterFinished(QDBusPendingCallWatcher*)));
+
+    return true;
+}
+
+void GnomeShortcutHandler::RegisterFinished(QDBusPendingCallWatcher* watcher) {
+    QDBusMessage reply = watcher->reply();
+    watcher->deleteLater();
+
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        tLog(LOGVERBOSE) << "Failed to grab media keys"
+               << reply.errorName() <<reply.errorMessage();
+        return;
+    }
+
+    connect(interface_, SIGNAL(MediaPlayerKeyPressed(QString,QString)),
+            this, SLOT(GnomeMediaKeyPressed(QString,QString)));
+
+    tLog(LOGVERBOSE) << "gnome media keys registered";
+}
+
+void
+GnomeShortcutHandler::GnomeMediaKeyPressed( const QString& app, const QString& val )
+{
+    if (app != QCoreApplication::applicationName())
+        return;
+
+    tLog(LOGVERBOSE) << "gnome media key " << val << " pressed";
+    if ( val == "Play" ) {
+        emit playPause();
+    }
+    if ( val == "Next" ) {
+        emit next();
+    }
+    if ( val == "Previous" ) {
+        emit previous();
+    }
+}
+

--- a/src/tomahawk/GnomeShortcutHandler.h
+++ b/src/tomahawk/GnomeShortcutHandler.h
@@ -1,0 +1,54 @@
+/* === This file is part of Tomahawk Player - <http://tomahawk-player.org> ===
+ *
+ *   Copyright 2013, Florian Richter <mail@f1ori.de>
+ *
+ *   Tomahawk is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Tomahawk is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Tomahawk. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GNOMESHORTCUTHANDLER_H
+#define GNOMESHORTCUTHANDLER_H
+
+#include "ShortcutHandler.h"
+#include "GnomeSettingsDaemonMediaKeysProxy.h"
+
+#include <QObject>
+
+namespace Tomahawk {
+
+
+class GnomeShortcutHandler : public ShortcutHandler
+{
+    Q_OBJECT
+public:
+    explicit GnomeShortcutHandler(QObject *parent = 0);
+    bool DoRegister();
+
+    static const char* kGsdService;
+    static const char* kGsdPath;
+    static const char* kGsdInterface;
+
+
+public slots:
+    void RegisterFinished(QDBusPendingCallWatcher* watcher);
+    void GnomeMediaKeyPressed( const QString& application, const QString& key );
+
+private:
+    org::gnome::SettingsDaemon::MediaKeys* interface_;
+
+};
+
+}
+
+#endif // GNOMESHORTCUTHANDLER_H
+

--- a/src/tomahawk/TomahawkApp.cpp
+++ b/src/tomahawk/TomahawkApp.cpp
@@ -94,6 +94,10 @@
 #include <sys/sysctl.h>
 #endif
 
+#ifdef WITH_GNOMESHORTCUTHANDLER
+#include "GnomeShortcutHandler.h"
+#endif
+
 #include <QPluginLoader>
 #include <QDir>
 #include <QMetaType>
@@ -235,6 +239,12 @@ TomahawkApp::init()
 
     Tomahawk::setApplicationHandler( this );
     increaseMaxFileDescriptors();
+#endif
+
+#ifdef WITH_GNOMESHORTCUTHANDLER
+    GnomeShortcutHandler *gnomeShortcutHandler = new GnomeShortcutHandler( this );
+    gnomeShortcutHandler->DoRegister();
+    m_shortcutHandler = QPointer<Tomahawk::ShortcutHandler>( gnomeShortcutHandler );
 #endif
 
     // Connect up shortcuts


### PR DESCRIPTION
- add shortcuthandler, which listens to the media key event
  provided by the gnome settings daemon via dbus
  (https://github.com/GNOME/gnome-settings-daemon/blob/master/plugins/media-keys/README.media-keys-API)
- fixes TWK-983
