### PR TITLE
Disable sorting of charts in Network Activity

### DIFF
--- a/src/libtomahawk/widgets/NetworkActivityWidget.cpp
+++ b/src/libtomahawk/widgets/NetworkActivityWidget.cpp
@@ -79,7 +79,6 @@ NetworkActivityWidget::NetworkActivityWidget( QWidget* parent )
     chartItem->appendRow( overallItem );
     d_func()->sortedProxy->setSourceModel( d_func()->crumbModelLeft );
     d_func()->ui->breadCrumbLeft->setModel( d_func()->sortedProxy );
-
     d_func()->ui->breadCrumbLeft->setVisible( true );
 }
 


### PR DESCRIPTION
Not sure if that's the right way to do it. Stuff in WhatsHotWidget looks way more sophisticated and includes, seems to me at least, a default selection in the dropdowns. In this case, the weekly activity would make sense as default.
