### PR TITLE
Put "out of %1" under the big number in StatsGauge

### DIFF
--- a/src/libtomahawk/widgets/StatsGauge.cpp
+++ b/src/libtomahawk/widgets/StatsGauge.cpp
@@ -81,7 +81,7 @@ StatsGauge::paintEvent( QPaintEvent* event )
         font.setPixelSize( 44 );
 
     p.setFont( font );
-    QRect textRect( 0, gaugeSize.height() / 2 - 14, gaugeSize.width(), 62 );
+    QRect textRect( 0, gaugeSize.height() / 2 - 44, gaugeSize.width(), 62 );
     p.drawText( textRect, Qt::AlignCenter, value() > 0 ? QString::number( value() ) : "-" );
 
     pen = QPen( TomahawkStyle::HEADER_GAUGE_TEXT.darker() );
@@ -91,7 +91,7 @@ StatsGauge::paintEvent( QPaintEvent* event )
     font.setPixelSize( 16 );
     p.setFont( font );
 
-    textRect = QRect( 0, gaugeSize.height() / 2 - 32, gaugeSize.width(), 20 );
+    textRect = QRect( 0, gaugeSize.height() / 2 + 22, gaugeSize.width(), 20 );
     p.drawText( textRect, Qt::AlignCenter, maximum() > 0 ? tr( "out of %1" ).arg( maximum() ) : "-" );
 
     if ( !m_text.isEmpty() )


### PR DESCRIPTION
"[number]\nout of %1" flows better than "out of %1\n[number]".

![isok7ce](https://f.cloud.github.com/assets/450939/686984/c6a420fc-da6d-11e2-8a9b-eaca7a8faff1.png)
![0qmwbfh](https://f.cloud.github.com/assets/450939/686985/c6a3a9d8-da6d-11e2-8cd6-7857523132af.png)
