### PR TITLE
Make hatchet account plugin Qt5 compatible

### DIFF
--- a/src/accounts/hatchet/account/HatchetAccount.cpp
+++ b/src/accounts/hatchet/account/HatchetAccount.cpp
@@ -20,6 +20,7 @@
 #include <QHostInfo>
 
 #include "HatchetAccountConfig.h"
+#include "TomahawkPlugin.h"
 #include "utils/Closure.h"
 #include "utils/Logger.h"
 #include "sip/HatchetSip.h"
@@ -116,7 +117,7 @@ AccountConfigWidget*
 HatchetAccount::configurationWidget()
 {
     if ( m_configWidget.isNull() )
-        m_configWidget = QWeakPointer<HatchetAccountConfig>( new HatchetAccountConfig( this ) );
+        m_configWidget = QPointer<HatchetAccountConfig>( new HatchetAccountConfig( this ) );
 
     return m_configWidget.data();
 }
@@ -172,7 +173,7 @@ HatchetAccount::sipPlugin()
     if ( m_tomahawkSipPlugin.isNull() )
     {
         tLog() << Q_FUNC_INFO;
-        m_tomahawkSipPlugin = QWeakPointer< HatchetSipPlugin >( new HatchetSipPlugin( this ) );
+        m_tomahawkSipPlugin = QPointer< HatchetSipPlugin >( new HatchetSipPlugin( this ) );
         connect( m_tomahawkSipPlugin.data(), SIGNAL( authUrlDiscovered( Tomahawk::Accounts::HatchetAccount::Service, QString ) ),
                  this, SLOT( authUrlDiscovered( Tomahawk::Accounts::HatchetAccount::Service, QString ) ) );
 

--- a/src/accounts/hatchet/account/HatchetAccount.h
+++ b/src/accounts/hatchet/account/HatchetAccount.h
@@ -40,6 +40,8 @@ class ACCOUNTDLLEXPORT HatchetAccountFactory : public AccountFactory
 {
     Q_OBJECT
     Q_INTERFACES( Tomahawk::Accounts::AccountFactory )
+    Q_PLUGIN_METADATA( IID "org.tomahawk-player.Player.AccountFactory" )
+
 public:
     HatchetAccountFactory();
     virtual ~HatchetAccountFactory();
@@ -48,7 +50,7 @@ public:
     virtual QString prettyName() const { return "Hatchet"; }
     virtual QString description() const { return tr( "Connect to your Hatchet account" ); }
     virtual bool isUnique() const { return true; }
-    AccountTypes types() const { return AccountTypes( SipType ); };
+    AccountTypes types() const { return AccountTypes( SipType ); }
 //    virtual bool allowUserCreation() const { return false; }
 #ifndef ENABLE_HEADLESS
     virtual QPixmap icon() const;
@@ -111,11 +113,11 @@ private:
 
     QVariantMap parseReply( QNetworkReply* reply, bool& ok ) const;
 
-    QWeakPointer<HatchetAccountConfig> m_configWidget;
+    QPointer<HatchetAccountConfig> m_configWidget;
 
     Account::ConnectionState m_state;
 
-    QWeakPointer< HatchetSipPlugin > m_tomahawkSipPlugin;
+    QPointer< HatchetSipPlugin > m_tomahawkSipPlugin;
     QHash< Service, QString > m_extraAuthUrls;
 
     static HatchetAccount* s_instance;

--- a/src/accounts/hatchet/sip/WebSocket.cpp
+++ b/src/accounts/hatchet/sip/WebSocket.cpp
@@ -105,7 +105,7 @@ WebSocket::disconnectWs( websocketpp::close::status::value status, const QString
     error_code ec;
     if ( m_connection )
     {
-        m_connection->close( status, reason.toAscii().constData(), ec );
+        m_connection->close( status, reason.toLatin1().constData(), ec );
         QMetaObject::invokeMethod( this, "readOutput", Qt::QueuedConnection );
         QTimer::singleShot( 5000, this, SLOT( disconnectSocket() ) ); //safety
         return;


### PR DESCRIPTION
Compiles and loads with Qt5, but I could not test functionality.

(QWeakPointers should only be used with QSharedPointers as their counterpart, not if GC is done via object hierachies)
