### PR TITLE
Update Nsis template to cleanly uninstall

### DIFF
--- a/CMakeModules/NSIS.template.in
+++ b/CMakeModules/NSIS.template.in
@@ -548,7 +548,9 @@ Section Uninstall
    DeleteRegValue HKLM "Software\Tomahawk" "VersionRevision"
    DeleteRegValue HKLM "Software\Tomahawk" ""
    DeleteRegKey HKLM "Software\Tomahawk"
-
+   
+   DeleteRegKey HKCR "Software\Tomahawk"
+   DeleteRegKey HKCR "Software\TomahawkSpotify"
    DeleteRegKey HKCR "tomahawk"
 
    ;Start menu shortcuts.


### PR DESCRIPTION
adding
 DeleteRegKey HKCR "Software\Tomahawk"
 DeleteRegKey HKCR "Software\TomahawkSpotify"
at line 552 and 553 fixes this
