### PR TITLE
change EchonestGenerator to the new Genre API of libechonest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,8 +301,8 @@ if(LIBCPP_FOUND AND APPLE)
 endif()
 
 
-macro_optional_find_package(Echonest 2.2.0)
-macro_log_feature(ECHONEST_FOUND "Echonest" "Qt library for communicating with The Echo Nest" "http://projects.kde.org/libechonest" TRUE "" "libechonest 2.2.0 is needed for dynamic playlists and the infosystem")
+macro_optional_find_package(Echonest 2.3.0)
+macro_log_feature(ECHONEST_FOUND "Echonest" "Qt library for communicating with The Echo Nest" "http://projects.kde.org/libechonest" TRUE "" "libechonest 2.3.0 is needed for dynamic playlists and the infosystem")
 
 find_package(Boost REQUIRED COMPONENTS filesystem system)
 macro_log_feature(Boost_FOUND "Boost" "Provides free peer-reviewed portable C++ source libraries" "http://www.boost.org" TRUE "" "") #FIXME: give useful explanation

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestControl.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestControl.cpp
@@ -1038,7 +1038,10 @@ Tomahawk::EchonestControl::insertMoodsStylesAndGenres()
     }
     else
     {
-        src = EchonestGenerator::genres();
+        foreach( const Echonest::Genre& genre, EchonestGenerator::genres() )
+        {
+            src.append( genre.name() );
+        }
     }
 
     QComboBox* combo = qobject_cast< QComboBox* >( m_input.data() );

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestControl.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestControl.cpp
@@ -1148,10 +1148,7 @@ Tomahawk::EchonestControl::insertMoodsStylesAndGenres()
     }
     else
     {
-        foreach( const Echonest::Genre& genre, EchonestGenerator::genres() )
-        {
-            src.append( genre.name() );
-        }
+        src = EchonestGenerator::genres();
     }
 
     QComboBox* combo = qobject_cast< QComboBox* >( m_input.data() );

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestControl.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestControl.cpp
@@ -509,6 +509,25 @@ Tomahawk::EchonestControl::updateWidgets()
         m_match = QPointer< QWidget >( match );
         m_input = QPointer< QWidget >( combo );
     }
+    else if( selectedType() == "Distribution" )
+    {
+        m_currentType = Echonest::DynamicPlaylist::Distribution;
+
+        QLabel* match = new QLabel( tr( "is" ) );
+
+        QComboBox* combo = new QComboBox();
+        combo->addItem( tr( "Focused", "Distribution: Songs that are tightly clustered around the seeds"), "focused" );
+        combo->addItem( tr( "Wandering", "Distribution: Songs from a broader range of artists"), "wandering" );
+
+        m_matchString = match->text();
+        m_matchData = match->text();
+
+        connect( combo, SIGNAL( activated( int ) ), this, SLOT( updateData() ) );
+        connect( combo, SIGNAL( activated( int ) ), this, SLOT( editingFinished() ) );
+
+        m_match = QPointer<QWidget>( match );
+        m_input = QPointer<QWidget>( combo );
+    }
     else
     {
         m_match = QPointer<QWidget>( new QWidget );
@@ -627,6 +646,15 @@ Tomahawk::EchonestControl::updateData()
         }
 
     }
+    else if( selectedType() == "Distribution" )
+    {
+        QComboBox* combo = qobject_cast< QComboBox* >( m_input.data() );
+        if ( combo )
+        {
+            m_data.first = Echonest::DynamicPlaylist::Distribution;
+            m_data.second = combo->itemData( combo->currentIndex() ).toString();
+        }
+    }
 
     calculateSummary();
 }
@@ -743,6 +771,13 @@ Tomahawk::EchonestControl::updateWidgetsFromData()
 
             QString songType = m_data.second.toString().split( ":" ).at( 0 );
             combo->setCurrentIndex( combo->findData( songType ) );
+        }
+    }
+    else if( selectedType() == "Distribution" )
+    {
+        QComboBox* combo = qobject_cast< QComboBox* >( m_input.data() );
+        if ( combo ) {
+            combo->setCurrentIndex( combo->findData( m_data.second.toString() ));
         }
     }
     calculateSummary();
@@ -1005,7 +1040,14 @@ Tomahawk::EchonestControl::calculateSummary()
         else
             summary = tr( "where song type is not %1" ).arg( text );
     }
+    else if ( selectedType() == "Distribution" )
+    {
+        Q_ASSERT( !m_input.isNull() );
+        Q_ASSERT( qobject_cast< QComboBox* >( m_input.data() ) );
+        QString text = qobject_cast< QComboBox* >( m_input.data() )->currentText().toLower();
 
+        summary = tr( "with a %1 distribution" ).arg( text );
+    }
     m_summary = summary;
 }
 

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -28,10 +28,12 @@
 #include "database/Database.h"
 #include "utils/Logger.h"
 #include "SourceList.h"
+
 #include <QFile>
 #include <QDir>
 #include <QReadWriteLock>
 #include <EchonestCatalogSynchronizer.h>
+#include <echonest/Genre.h>
 
 using namespace Tomahawk;
 
@@ -713,7 +715,7 @@ EchonestGenerator::loadGenres()
             {
                 s_genres_lock.lockForWrite();
                 tLog() << "Genres not in cache or too old, refetching genres ...";
-                s_genresJob = Echonest::Artist::fetchGenres();
+                s_genresJob = Echonest::Genre::fetchList();
                 connect( s_genresJob, SIGNAL( finished() ), this, SLOT( genresReceived() ) );
             }
         }

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -808,6 +808,8 @@ EchonestGenerator::genresReceived()
     }
     s_genresJob = 0;
 
+    qRegisterMetaType< Echonest::Genre >( "enGenre" );
+    qRegisterMetaType< Echonest::Genres >( "enGenres" );
     TomahawkUtils::Cache::instance()->putData( "EchonestGenerator", 1209600000 /* 2 weeks */, "genres", QVariant::fromValue< Echonest::Genres >( s_genres ) );
     s_genres_lock.unlock();
     emit genresSaved();

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -816,23 +816,3 @@ EchonestGenerator::genresReceived()
     s_genres_lock.unlock();
     emit genresSaved();
 }
-
-QDataStream&
-operator<<(QDataStream& out, const Echonest::Genre &genre)
-{
-    //TODO: this should be made more complete and be moved to libechonest
-    return out << genre.name() << genre.description();
-}
-
-QDataStream&
-operator>>(QDataStream& in, Echonest::Genre& genre)
-{
-    //TODO: this should be made more complete and be moved to libechonest
-    QString name;
-    QString description;
-    in >> name;
-    in >> description;
-    genre.setName( name );
-    genre.setDescription( description );
-    return in;
-}

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -715,7 +715,7 @@ EchonestGenerator::loadGenres()
             {
                 s_genres_lock.lockForWrite();
                 tLog() << "Genres not in cache or too old, refetching genres ...";
-                s_genresJob = Echonest::Genre::fetchList();
+                s_genresJob = Echonest::Genre::fetchList( Echonest::GenreInformation(), 2000 );
                 connect( s_genresJob, SIGNAL( finished() ), this, SLOT( genresReceived() ) );
             }
         }

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -705,6 +705,7 @@ EchonestGenerator::loadGenres()
     {
         if ( s_genres_lock.tryLockForRead() )
         {
+            qRegisterMetaTypeStreamOperators< Echonest::Genre >( "enGenre" );
             QVariant genres = TomahawkUtils::Cache::instance()->getData( "EchonestGenerator", "genres" );
             s_genres_lock.unlock();
             if ( genres.isValid() && genres.canConvert< Echonest::Genres >() )
@@ -808,9 +809,28 @@ EchonestGenerator::genresReceived()
     }
     s_genresJob = 0;
 
-    qRegisterMetaType< Echonest::Genre >( "enGenre" );
-    qRegisterMetaType< Echonest::Genres >( "enGenres" );
+    qRegisterMetaTypeStreamOperators< Echonest::Genre >( "enGenre" );
     TomahawkUtils::Cache::instance()->putData( "EchonestGenerator", 1209600000 /* 2 weeks */, "genres", QVariant::fromValue< Echonest::Genres >( s_genres ) );
     s_genres_lock.unlock();
     emit genresSaved();
+}
+
+QDataStream&
+operator<<(QDataStream& out, const Echonest::Genre &genre)
+{
+    //TODO: this should be made more complete and be moved to libechonest
+    return out << genre.name() << genre.description();
+}
+
+QDataStream&
+operator>>(QDataStream& in, Echonest::Genre& genre)
+{
+    //TODO: this should be made more complete and be moved to libechonest
+    QString name;
+    QString description;
+    in >> name;
+    in >> description;
+    genre.setName( name );
+    genre.setDescription( description );
+    return in;
 }

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -33,14 +33,13 @@
 #include <QDir>
 #include <QReadWriteLock>
 #include <EchonestCatalogSynchronizer.h>
-#include <echonest/Genre.h>
 
 using namespace Tomahawk;
 
 
 QStringList EchonestGenerator::s_moods = QStringList();
 QStringList EchonestGenerator::s_styles = QStringList();
-QStringList EchonestGenerator::s_genres = QStringList();
+Echonest::Genres EchonestGenerator::s_genres = Echonest::Genres();
 QNetworkReply* EchonestGenerator::s_moodsJob = 0;
 QNetworkReply* EchonestGenerator::s_stylesJob = 0;
 QNetworkReply* EchonestGenerator::s_genresJob = 0;
@@ -707,9 +706,9 @@ EchonestGenerator::loadGenres()
         {
             QVariant genres = TomahawkUtils::Cache::instance()->getData( "EchonestGenerator", "genres" );
             s_genres_lock.unlock();
-            if ( genres.isValid() && genres.canConvert< QStringList >() )
+            if ( genres.isValid() && genres.canConvert< Echonest::Genres >() )
             {
-                s_genres = genres.toStringList();
+                s_genres = genres.value< Echonest::Genres >();
             }
             else
             {
@@ -785,7 +784,7 @@ EchonestGenerator::stylesReceived()
     emit stylesSaved();
 }
 
-QStringList
+Echonest::Genres
 EchonestGenerator::genres()
 {
     return s_genres;
@@ -800,7 +799,7 @@ EchonestGenerator::genresReceived()
 
     try
     {
-        s_genres = Echonest::Artist::parseGenreList( r ).toList();
+        s_genres = Echonest::Genre::parseList( r );
     }
     catch( Echonest::ParseError& e )
     {
@@ -808,7 +807,7 @@ EchonestGenerator::genresReceived()
     }
     s_genresJob = 0;
 
-    TomahawkUtils::Cache::instance()->putData( "EchonestGenerator", 1209600000 /* 2 weeks */, "genres", QVariant::fromValue< QStringList >( s_genres ) );
+    TomahawkUtils::Cache::instance()->putData( "EchonestGenerator", 1209600000 /* 2 weeks */, "genres", QVariant::fromValue< Echonest::Genres >( s_genres ) );
     s_genres_lock.unlock();
     emit genresSaved();
 }

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.cpp
@@ -85,7 +85,8 @@ EchonestFactory::typeSelectors() const
                           << QT_TRANSLATE_NOOP( "Type selector", "Song Hotttnesss" ) << QT_TRANSLATE_NOOP( "Type selector", "Longitude" )
                           << QT_TRANSLATE_NOOP( "Type selector", "Latitude" ) << QT_TRANSLATE_NOOP( "Type selector", "Mode" )
                           << QT_TRANSLATE_NOOP( "Type selector", "Key" ) << QT_TRANSLATE_NOOP( "Type selector", "Sorting" )
-                          << QT_TRANSLATE_NOOP( "Type selector", "Song Type" );
+                          << QT_TRANSLATE_NOOP( "Type selector", "Song Type" ) << QT_TRANSLATE_NOOP( "Type selector", "Distribution" )
+                          << QT_TRANSLATE_NOOP( "Type selector", "Genre Preset" );
 
     return types;
 }

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
@@ -31,8 +31,10 @@
 
 #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 #include <echonest5/Playlist.h>
+#include <echonest5/Genre.h>
 #else
 #include <echonest/Playlist.h>
+#include <echonest/Genre.h>
 #endif
 
 namespace Tomahawk
@@ -88,7 +90,7 @@ public:
 
     static QStringList styles();
     static QStringList moods();
-    static QStringList genres();
+    static Echonest::Genres genres();
     static QStringList userCatalogs();
     static QByteArray catalogId( const QString& collectionId );
 
@@ -133,7 +135,7 @@ private:
 
     static QStringList s_styles;
     static QStringList s_moods;
-    static QStringList s_genres;
+    static Echonest::Genres s_genres;
     static QNetworkReply* s_stylesJob;
     static QNetworkReply* s_moodsJob;
     static QNetworkReply* s_genresJob;

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
@@ -149,5 +149,10 @@ private:
 
 };
 
+//TODO: this code should be move to libechonest
+//TODO: (delete this when libechonest 2.4 is out)
+QDataStream& operator<<(QDataStream& out, const Echonest::Genre& genre);
+QDataStream& operator>>(QDataStream& in, Echonest::Genre& genre);
+
 #endif
 

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
@@ -34,6 +34,7 @@
 #include <echonest5/Genre.h>
 #else
 #include <echonest/Playlist.h>
+#include <echonest/Genre.h>
 #endif
 
 namespace Tomahawk

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
@@ -90,7 +90,7 @@ public:
 
     static QStringList styles();
     static QStringList moods();
-    static Echonest::Genres genres();
+    static QStringList genres();
     static QStringList userCatalogs();
     static QByteArray catalogId( const QString& collectionId );
 
@@ -135,7 +135,7 @@ private:
 
     static QStringList s_styles;
     static QStringList s_moods;
-    static Echonest::Genres s_genres;
+    static QStringList s_genres;
     static QNetworkReply* s_stylesJob;
     static QNetworkReply* s_moodsJob;
     static QNetworkReply* s_genresJob;
@@ -148,11 +148,6 @@ private:
 };
 
 };
-
-//TODO: this code should be move to libechonest
-//TODO: (delete this when libechonest 2.4 is out)
-QDataStream& operator<<(QDataStream& out, const Echonest::Genre& genre);
-QDataStream& operator>>(QDataStream& in, Echonest::Genre& genre);
 
 #endif
 

--- a/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
+++ b/src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h
@@ -34,7 +34,6 @@
 #include <echonest5/Genre.h>
 #else
 #include <echonest/Playlist.h>
-#include <echonest/Genre.h>
 #endif
 
 namespace Tomahawk


### PR DESCRIPTION
Echonest added a new genre API and deprecated the old Artist:list_genres API call. The new genres API exists already in libechonest and the old call is also deprecated in libechonest.
So Tomahawk should use the new API.

Warning: Needs libechonest master (or v2.3.0 when it gets released)