### PR TITLE
Fix seeking to the end of a track.

### DIFF
--- a/src/libtomahawk/audio/AudioEngine.cpp
+++ b/src/libtomahawk/audio/AudioEngine.cpp
@@ -103,7 +103,8 @@ AudioEnginePrivate::onStateChanged( Phonon::State newState, Phonon::State oldSta
         q_ptr->setState( AudioEngine::Stopped );
     }
 
-    if ( oldState == Phonon::PlayingState )
+    //TODO- Only seek on click/release (or similar fix), else this has some nasty effects.
+    if ( oldState == Phonon::PlayingState || oldState == Phonon::BufferingState)
     {
         bool stopped = false;
         switch ( newState )

--- a/src/libtomahawk/audio/AudioEngine.cpp
+++ b/src/libtomahawk/audio/AudioEngine.cpp
@@ -103,7 +103,6 @@ AudioEnginePrivate::onStateChanged( Phonon::State newState, Phonon::State oldSta
         q_ptr->setState( AudioEngine::Stopped );
     }
 
-    //TODO- Only seek on click/release (or similar fix), else this has some nasty effects.
     if ( oldState == Phonon::PlayingState || oldState == Phonon::BufferingState)
     {
         bool stopped = false;

--- a/src/libtomahawk/utils/TomahawkUtils.cpp
+++ b/src/libtomahawk/utils/TomahawkUtils.cpp
@@ -173,12 +173,12 @@ appDataDir()
         if ( ( QSysInfo::WindowsVersion & QSysInfo::WV_DOS_based ) == 0 )
         {
             // Use this for non-DOS-based Windowses
-            char acPath[MAX_PATH];
-            HRESULT h = SHGetFolderPathA( NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE,
+            wchar_t acPath[MAX_PATH];
+            HRESULT h = SHGetFolderPathW( NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE,
                                           NULL, 0, acPath );
             if ( h == S_OK )
             {
-                path = QString::fromLocal8Bit( acPath );
+                path = QString::fromUtf16( (ushort*)acPath );
             }
         }
     #elif defined(Q_OS_MAC)

--- a/src/libtomahawk/widgets/SeekSlider.cpp
+++ b/src/libtomahawk/widgets/SeekSlider.cpp
@@ -68,6 +68,9 @@ SeekSlider::~SeekSlider()
 void
 SeekSlider::mousePressEvent( QMouseEvent* event )
 {
+    //Start a new scrub.
+    isNewScrub = true;
+
     if ( event->button() == Qt::LeftButton )
     {
         QMouseEvent eventSwap( QEvent::MouseButtonRelease, event->pos(), event->globalPos(), Qt::MidButton, Qt::MidButton, event->modifiers() );
@@ -77,6 +80,16 @@ SeekSlider::mousePressEvent( QMouseEvent* event )
         QSlider::mousePressEvent( event );
 }
 
+void
+SeekSlider::mouseMoveEvent( QMouseEvent* event)
+{
+    // Check that scrubbing isn't carried over after SeekSlider change.
+    if (isNewScrub)
+        QSlider::mouseMoveEvent (event);
+}
+
+void
+SeekSlider::scrubReset(){ isNewScrub = false; }
 
 void
 SeekSlider::setValue( int value )

--- a/src/libtomahawk/widgets/SeekSlider.h
+++ b/src/libtomahawk/widgets/SeekSlider.h
@@ -39,17 +39,19 @@ public:
 
     void setAcceptWheelEvents( bool b ) { m_acceptWheelEvents = b; }
 
-    //override and disable scrubbing
-    void mouseMoveEvent( QMouseEvent* event) { return; }
-
 public slots:
     void setValue( int value );
+    void scrubReset();
 
 protected:
+
     void mousePressEvent( QMouseEvent* event );
+    void mouseMoveEvent( QMouseEvent* event);
     void wheelEvent( QWheelEvent* event );
 
 private:
+
+    bool isNewScrub = false;
     QTimeLine* m_timeLine;
     bool m_acceptWheelEvents;
 };

--- a/src/libtomahawk/widgets/SeekSlider.h
+++ b/src/libtomahawk/widgets/SeekSlider.h
@@ -39,6 +39,9 @@ public:
 
     void setAcceptWheelEvents( bool b ) { m_acceptWheelEvents = b; }
 
+    //override and disable scrubbing
+    void mouseMoveEvent( QMouseEvent* event) { return; }
+
 public slots:
     void setValue( int value );
 

--- a/src/tomahawk/AudioControls.cpp
+++ b/src/tomahawk/AudioControls.cpp
@@ -272,6 +272,7 @@ AudioControls::onPlaybackStarted( const Tomahawk::result_ptr result )
     if ( duration == -1 || duration == 0 )
         duration = result.data()->track()->duration() * 1000;
 
+    ui->seekSlider->scrubReset();
     ui->seekSlider->setRange( 0, duration );
     ui->seekSlider->setValue( 0 );
     ui->seekSlider->setEnabled( AudioEngine::instance()->canSeek() );


### PR DESCRIPTION
Issue highlighted here: https://bugs.tomahawk-player.org/browse/TWK-1703

By doing this I had to disable the scrubbing behaviour (Which wasn't quite there anyway. I'd think you'd have to perform this by altering the playback speed, and only seeking for instantaneous changes. Obviously this wouldn't work well for remote sources though.)

The seeking occurs on mouse click, not on mouse release. idk if this is preferred with you guys?