### PR TITLE
Use albumartist in DatabaseCommand_AddFiles

### DIFF
--- a/src/libtomahawk/database/DatabaseCommand_AddFiles.cpp
+++ b/src/libtomahawk/database/DatabaseCommand_AddFiles.cpp
@@ -131,8 +131,9 @@ DatabaseCommand_AddFiles::exec( DatabaseImpl* dbi )
         // this is the qvariant(map) the remote will get
         v = m;
 
-        // add the album artist to the artist database
-        albumartistid = dbi->artistId( albumartist, true );
+        // add the album artist to the artist database.
+	if( !albumartist.trimmed().isEmpty() )
+	  albumartistid = dbi->artistId( albumartist, true );
         
 	if( !artist.trimmed().isEmpty() )
         	artistid = dbi->artistId( artist, true );


### PR DESCRIPTION
So far, the album database uses the track artist. This changes it to use the album artist if one is available. This will alter the use of the artist field in the album database, but it shouldn't create any issues according to muesli and xhochy. This is in order to prepare for a more cleaned up collection view which only lists album artists if requested.
