### PR TITLE
Look into the list of driver instead of probing.

### DIFF
--- a/src/libtomahawk/database/DatabaseImpl.cpp
+++ b/src/libtomahawk/database/DatabaseImpl.cpp
@@ -739,10 +739,15 @@ Tomahawk::DatabaseImpl::openDatabase( const QString& dbname, bool checkSchema )
     {
         if ( sqlDriver.isEmpty() )
         {
-            sqlDriver = QString( "QSQLITE3" );
-            QSqlDatabase testdb = QSqlDatabase::addDatabase( sqlDriver, "testDriverConnection" );
-            if ( !testdb.isValid() )
-                sqlDriver = QString( "QSQLITE" );
+            QStringList drivers = QSqlDatabase::drivers();
+            if (drivers.contains( "QSQLITE3" ))
+            {
+                sqlDriver = "QSQLITE3";
+            }
+            else
+            {
+                sqlDriver = "QSQLITE";
+            }
         }
 
         QSqlDatabase db = QSqlDatabase::addDatabase( sqlDriver, connName );


### PR DESCRIPTION
This eliminates a Qt warning about a not available QSql backend.
