### PR TITLE
Buildfixes freebsd

### DIFF
--- a/src/accounts/zeroconf/CMakeLists.txt
+++ b/src/accounts/zeroconf/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories( ${LIBATTICA_INCLUDE_DIR})
 
 tomahawk_add_plugin(zeroconf
     TYPE account

--- a/src/infoplugins/linux/CMakeLists.txt
+++ b/src/infoplugins/linux/CMakeLists.txt
@@ -11,7 +11,7 @@ tomahawk_add_plugin(fdonotify
     SOURCES "${fdo_srcs}" LINK_LIBRARIES "${FDO_LINK_LIBRARIES}"
 )
 
-INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} )
+INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} ${LIBATTICA_INCLUDE_DIR})
 SET(mpris_srcs
     mpris/MprisPlugin.cpp
     )

--- a/src/libtomahawk-playdarapi/CMakeLists.txt
+++ b/src/libtomahawk-playdarapi/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND ${TOMAHAWK_PLAYDARAPI_LIBRARY_TARGET}_UI
 include_directories(
     ${QXTWEB_INCLUDE_DIRS}
     ${THIRDPARTY_DIR}/qt-certificate-addon/src/
+    ${LIBATTICA_INCLUDE_DIR}
     )
 
 tomahawk_add_library(${TOMAHAWK_PLAYDARAPI_LIBRARY_TARGET}

--- a/src/libtomahawk/utils/TomahawkUtils.cpp
+++ b/src/libtomahawk/utils/TomahawkUtils.cpp
@@ -21,6 +21,8 @@
 
 #include "utils/TomahawkUtils.h"
 
+#include "unistd.h"
+
 #include "config.h"
 
 #include <unistd.h>
@@ -185,7 +187,7 @@ appDataDir()
         }
     #elif defined(Q_OS_MAC)
         path = appSupportFolderPath();
-    #elif defined(Q_OS_LINUX)
+    #elif defined(Q_OS_UNIX)
         path = QDir::home().filePath( ".local/share" );
     #else
         path = QCoreApplication::applicationDirPath();

--- a/src/libtomahawk/utils/TomahawkUtils.cpp
+++ b/src/libtomahawk/utils/TomahawkUtils.cpp
@@ -23,6 +23,8 @@
 
 #include "config.h"
 
+#include <unistd.h>
+
 #include "BinaryExtractWorker.h"
 #include "Query.h"
 #include "SharedTimeLine.h"

--- a/src/tools/tomahawk-test-musicscan/CMakeLists.txt
+++ b/src/tools/tomahawk-test-musicscan/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${LIBATTICA_INCLUDE_DIR})
+
 set( tomahawk_test_musicscan_src
     main.cpp
 )

--- a/src/viewpages/charts/CMakeLists.txt
+++ b/src/viewpages/charts/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${LIBATTICA_INCLUDE_DIR})
+
 tomahawk_add_plugin(charts
     TYPE viewpage
     EXPORT_MACRO TOMAHAWK_VIEWPAGE_EXPORT_PRO

--- a/src/viewpages/dashboard/CMakeLists.txt
+++ b/src/viewpages/dashboard/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${Boost_INCLUDE_DIRS})
+
 tomahawk_add_plugin(dashboard
     TYPE viewpage
     EXPORT_MACRO TOMAHAWK_VIEWPAGE_EXPORT_PRO

--- a/src/viewpages/whatsnew_0_8/CMakeLists.txt
+++ b/src/viewpages/whatsnew_0_8/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(${LIBATTICA_INCLUDE_DIR})
+
 tomahawk_add_plugin(whatsnew_0_8
     TYPE viewpage
     EXPORT_MACRO TOMAHAWK_VIEWPAGE_EXPORT_PRO

--- a/thirdparty/qt-certificate-addon/src/certificate/CMakeLists.txt
+++ b/thirdparty/qt-certificate-addon/src/certificate/CMakeLists.txt
@@ -18,7 +18,7 @@ list(APPEND qtcertificateaddon_SOURCES
     utils.cpp
 )
 
-include_directories(${qtcertificateaddon_INCLUDE_DIRECTORIES})
+include_directories(${qtcertificateaddon_INCLUDE_DIRECTORIES} ${GNUTLS_INCLUDE_DIR})
 add_library(qtcertificateaddon STATIC ${qtcertificateaddon_SOURCES})
 set_target_properties(
     qtcertificateaddon


### PR DESCRIPTION
Changes required to build tomahawk master on FreeBSD.

1 missing include
Several missing cmake INCLUDE_DIR variables missing