### PR TITLE
Add check for libvlc_set_app_id being available as its only from 2.1.0 (...

### DIFF
--- a/src/libtomahawk/audio/AudioOutput.cpp
+++ b/src/libtomahawk/audio/AudioOutput.cpp
@@ -95,8 +95,10 @@ AudioOutput::AudioOutput( QObject* parent )
     libvlc_set_user_agent( m_vlcInstance, TOMAHAWK_APPLICATION_NAME,
                            TOMAHAWK_APPLICATION_NAME "/" TOMAHAWK_VERSION );
     // FIXME: icon is named tomahawk, so we need the lowercase application name
+#if (LIBVLC_VERSION_INT >= LIBVLC_VERSION(2, 1, 0, 0))
     libvlc_set_app_id( m_vlcInstance, "org.tomahawk-player.desktop",
                        TOMAHAWK_VERSION, "tomahawk" );
+#endif
 
 
 


### PR DESCRIPTION
...this allows tomahawk to be built with older libvlc on something like Ubuntu 12.04