### PR TITLE
Don't override settings.method in Tomahawk.ajax. 

### DIFF
--- a/data/js/tomahawk.js
+++ b/data/js/tomahawk.js
@@ -492,8 +492,8 @@ Tomahawk.ajax = function(url, settings) {
         settings.url = url;
     }
 
+    settings.type = settings.type || settings.method || 'get';
     settings.method = settings.type;
-    settings.type = settings.type || 'get';
 
     if (settings.data) {
         var formEncode = function(obj) {


### PR DESCRIPTION
Not sure if settings.type is ever different than settings.method. But i kept both anyway, and left type with precedence.