### PR TITLE
Use correct method to encode a JSON string in failed script result.

### DIFF
--- a/data/js/tomahawk.js
+++ b/data/js/tomahawk.js
@@ -790,7 +790,7 @@ Tomahawk.PluginManager = {
             } else {
                 Tomahawk.reportScriptJobResults({
                     requestId: requestId,
-                    error: "Scripts need to return objects for requests: methodName: " + methodName + " params: " + JSON.encode(params)
+                    error: "Scripts need to return objects for requests: methodName: " + methodName + " params: " + JSON.stringify(params)
                 });
             }
         }, function (error) {


### PR DESCRIPTION
Little bug you can only find by making a resolver bug.

Can't build here. But JSON.stringify is used directly in the same script. So I can't imagine this wont work fine.

EDIT: To clarify, JSON.encode doesn't exist. 