### PR TITLE
Fix condition to check number of active queries

### DIFF
--- a/src/libtomahawk/Pipeline.cpp
+++ b/src/libtomahawk/Pipeline.cpp
@@ -515,7 +515,7 @@ Pipeline::shuntNext()
         }
 
         // Check if we are ready to dispatch more queries
-        if ( d->qidsState.count() >= d->maxConcurrentQueries )
+        if ( activeQueryCount() >= d->maxConcurrentQueries )
             return;
 
         /*


### PR DESCRIPTION
Not sure if thats the reason for lfranchi's issue but its definitenly a bug.
