### PR TITLE
[musicbrainz]Use disambiguation as album name if available

### DIFF
--- a/src/infoplugins/generic/musicbrainz/MusicBrainzPlugin.cpp
+++ b/src/infoplugins/generic/musicbrainz/MusicBrainzPlugin.cpp
@@ -177,6 +177,10 @@ MusicBrainzPlugin::gotReleaseGroupsSlot()
             for ( int i = 0; i < releaseGroupsNL.count(); i++ )
             {
                 QString groupTitle = releaseGroupsNL.at(i).firstChildElement("title").text();
+                if (!releaseGroupsNL.at(i).firstChildElement("disambiguation").isNull())
+                {
+                    groupTitle = releaseGroupsNL.at(i).firstChildElement("disambiguation").text();
+                }
                 QString a = releaseGroupsNL.at(i).firstChildElement( "artist-credit" ).firstChildElement( "name-credit" ).firstChildElement( "artist" ).firstChildElement( "name" ).text();
                 QString id = releaseGroupsNL.at(i).firstChildElement( "artist-credit" ).firstChildElement( "name-credit" ).firstChildElement( "artist" ).attribute( "id" );
                 if ( !albums.contains( groupTitle ) && id == popularId && a.normalized( QString::NormalizationForm_KC ).compare(hash["artist"].normalized( QString::NormalizationForm_KC ), Qt::CaseInsensitive) == 0 )


### PR DESCRIPTION
Other options would be to use
Title (disambiguation)
or
Title disambiguation

Though this one works perfectly fine for me for the following case:
https://bugs.tomahawk-player.org/browse/TWK-2123

(3 albums "Crystal Castles")
