### PR TITLE
fix for next track not getting triggered when seeking to/past the end with a mouse

### DIFF
--- a/src/libtomahawk/audio/AudioOutput.cpp
+++ b/src/libtomahawk/audio/AudioOutput.cpp
@@ -431,6 +431,11 @@ AudioOutput::seek( qint64 milliseconds )
     {
 
         //    tDebug() << Q_FUNC_INFO << "AudioOutput:: seeking" << milliseconds << "msec";
+
+        // for some tracks, seeking to an end seems not to work correctly with libvlc
+        // (tracks enter a random and infinite loop) - this is a temporary fix for that
+        if (milliseconds == libvlc_media_player_get_length(m_vlcPlayer) && milliseconds > 0)
+            milliseconds -= 1;
         libvlc_media_player_set_time( m_vlcPlayer, milliseconds );
         setCurrentTime( milliseconds );
     }

--- a/src/libtomahawk/audio/AudioOutput.cpp
+++ b/src/libtomahawk/audio/AudioOutput.cpp
@@ -427,21 +427,19 @@ AudioOutput::seek( qint64 milliseconds )
             return;
     }
 
+    qint64 duration = AudioEngine::instance()->currentTrackTotalTime();
+    // for some tracks, seeking to an end seems not to work correctly with libvlc
+    // (tracks enter a random and infinite loop) - this is a temporary fix for that
+    if (duration == milliseconds)
+        milliseconds -= 1;
+
     if ( m_seekable )
     {
-
-        //    tDebug() << Q_FUNC_INFO << "AudioOutput:: seeking" << milliseconds << "msec";
-
-        // for some tracks, seeking to an end seems not to work correctly with libvlc
-        // (tracks enter a random and infinite loop) - this is a temporary fix for that
-        if (milliseconds == libvlc_media_player_get_length(m_vlcPlayer) && milliseconds > 0)
-            milliseconds -= 1;
         libvlc_media_player_set_time( m_vlcPlayer, milliseconds );
         setCurrentTime( milliseconds );
     }
     else
     {
-        qint64 duration = AudioEngine::instance()->currentTrackTotalTime();
         float position = float(float(milliseconds) / duration);
         libvlc_media_player_set_position(m_vlcPlayer, position);
         tDebug() << Q_FUNC_INFO << "AudioOutput:: seeking via position" << position << "pos";

--- a/src/libtomahawk/widgets/SeekSlider.cpp
+++ b/src/libtomahawk/widgets/SeekSlider.cpp
@@ -33,6 +33,7 @@ SeekSlider::SeekSlider( QWidget* parent )
     , TomahawkUtils::DpiScaler( this )
     , m_timeLine( 0 )
     , m_acceptWheelEvents( true )
+    , m_isScrubbing( false )
 {
     setStyleSheet( QString(
                    "QSlider::groove:horizontal {"
@@ -72,6 +73,8 @@ SeekSlider::mousePressEvent( QMouseEvent* event )
 {
     if ( event->button() == Qt::LeftButton )
     {
+        m_isScrubbing = true;
+
         QMouseEvent eventSwap( QEvent::MouseButtonRelease, event->pos(), event->globalPos(), Qt::MidButton, Qt::MidButton, event->modifiers() );
         QSlider::mousePressEvent( &eventSwap );
     }
@@ -106,4 +109,21 @@ SeekSlider::wheelEvent( QWheelEvent* event )
         return;
     }
     event->ignore();
+}
+
+
+void
+SeekSlider::mouseMoveEvent( QMouseEvent* event )
+{
+    if (!m_isScrubbing)
+        return;
+
+    // disable further scrubbing when we're past the slider's right margin
+    if (event->pos().x() > width())
+    {
+        m_isScrubbing = false;
+        return;
+    }
+
+    QSlider::mouseMoveEvent(event);
 }

--- a/src/libtomahawk/widgets/SeekSlider.h
+++ b/src/libtomahawk/widgets/SeekSlider.h
@@ -44,11 +44,13 @@ public slots:
 
 protected:
     void mousePressEvent( QMouseEvent* event );
+    void mouseMoveEvent( QMouseEvent* event );
     void wheelEvent( QWheelEvent* event );
 
 private:
     QTimeLine* m_timeLine;
     bool m_acceptWheelEvents;
+    bool m_isScrubbing;
 };
 
 #endif // SEEKSLIDER_H


### PR DESCRIPTION
This is basically same fix as #255 but with a different implementation: the case when user drags the mouse past the slider's end is handled entirely inside the SeekSlider itself. Scrubbing starts with the mouse press but the difference is that it ends once the user dragged the mouse past the slider's right margin (on a whole y-axis). I found this implementation cleaner since there is no need to reset scrubbing from outside. I've tested this and it correctly triggers the next song now. Hopefully I don't miss something obvious here and this solution is ok for You guys.