### PR TITLE
[Proof of Concept] Album art as Windows window preview

### DIFF
--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -576,7 +576,7 @@ TomahawkWindow::updatePreview()
     QString title( "Tomahawk" );
     if ( !m_currentTrack.isNull() ) {
         cover = m_currentTrack->track()->albumPtr()->cover( coverSize , false );
-        title = tr( "%1<br><br><br>%2</b>", "artist name, track" ).arg( m_currentTrack->track()->artist(), m_currentTrack->track()->track() );
+        title = tr( "%1<br><br><br><b>%2</b>", "track, artist name" ).arg( m_currentTrack->track()->track(), m_currentTrack->track()->artist() );
     }
     if ( cover.isNull() ) {
         cover = TomahawkUtils::defaultPixmap( TomahawkUtils::DefaultAlbumCover , TomahawkUtils::Original, coverSize );

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -530,9 +530,7 @@ TomahawkWindow::setupWindowsButtons()
 {
     m_taskbarList = new QWinThumbnailToolBar( this );
     m_taskbarList->setWindow( this->windowHandle() );
-    m_taskbarList->setIconicPixmapNotificationsEnabled( true );
-    connect( m_taskbarList , &QWinThumbnailToolBar::iconicThumbnailPixmapRequested , this , &TomahawkWindow::updatePreview);
-    connect( m_taskbarList , &QWinThumbnailToolBar::iconicLivePreviewPixmapRequested , this , &TomahawkWindow::updatePreview);
+    updatePreview();
 
     QWinThumbnailToolButton *back = new QWinThumbnailToolButton( m_taskbarList );
     back->setToolTip( tr( "Back" ) );
@@ -571,11 +569,10 @@ TomahawkWindow::setupWindowsButtons()
 void
 TomahawkWindow::updatePreview()
 {
-    qDebug() << "Update cover";
-    const QSize coverSize( 500 , 500 );
-    const QSize size(900,600);
+    const QSize size = QDesktopWidget().availableGeometry().size();
+    const QSize coverSize( size.height() * 0.75 , size.height() * 0.75 );
+
     QPixmap cover;
-    
     if ( !AudioEngine::instance()->currentTrack().isNull() ) {
         cover = AudioEngine::instance()->currentTrack()->track()->albumPtr()->cover( coverSize , false );
     }
@@ -583,17 +580,17 @@ TomahawkWindow::updatePreview()
         cover = TomahawkUtils::defaultPixmap( TomahawkUtils::DefaultAlbumCover , TomahawkUtils::Original, coverSize );
     }
 
-    QPixmap thumb(size);
-    thumb.fill(Qt::white);
+    QPixmap thumb( size );
+    thumb.fill( Qt::white );
 
     QPainter paint(&thumb);
-    paint.drawPixmap((size.width() - coverSize.width())/2 ,0, coverSize.width(), coverSize.height(), cover);
+    paint.drawPixmap((size.width() - coverSize.width()) / 2 ,0, coverSize.width(), coverSize.height(), cover);
 
     QFont font = paint.font();
-    font.setPointSize(40);
-    paint.setFont(font);
-    paint.setPen(Qt::black);
-    paint.drawText(QRect(0,coverSize.height(),size.width(),size.height() - coverSize.height()),windowTitle());
+    font.setPixelSize( size.height() * 0.1 );
+    paint.setFont( font );
+    paint.setPen( Qt::black );
+    paint.drawText( QRect( 0 , coverSize.height() , size.width() , size.height() - coverSize.height() ) , windowTitle() , QTextOption( Qt::AlignCenter ) );
 
     m_taskbarList->setIconicThumbnailPixmap( thumb );
     m_taskbarList->setIconicLivePreviewPixmap( thumb );

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -576,30 +576,37 @@ TomahawkWindow::updatePreview()
     QString title( "Tomahawk" );
     if ( !m_currentTrack.isNull() ) {
         cover = m_currentTrack->track()->albumPtr()->cover( coverSize , false );
-        title = tr( "%1<br><br><br><b>%2</b>", "artist name, track" ).arg( m_currentTrack->track()->artist(), m_currentTrack->track()->track() );
+        title = tr( "%1<br><br><br>%2</b>", "artist name, track" ).arg( m_currentTrack->track()->artist(), m_currentTrack->track()->track() );
     }
     if ( cover.isNull() ) {
         cover = TomahawkUtils::defaultPixmap( TomahawkUtils::DefaultAlbumCover , TomahawkUtils::Original, coverSize );
     }
 
     QPixmap thumb( size );
-    thumb.fill( QColor("#FF004C") );
+    thumb.fill( QColor( "#FF004C" ) );
 
-    QPainter paint(&thumb);
-    paint.drawPixmap(margin , margin, coverSize.width(), coverSize.height(), cover);
+    QPainter paint( &thumb );
+
+    QPen pen = paint.pen();
+    pen.setColor( Qt::white );
+    pen.setWidth( size.height() * 0.01 );
+    paint.setPen( pen );
+
+    paint.drawPixmap(margin , margin , coverSize.width() , coverSize.height() , cover );
+    paint.drawRect( margin , margin , coverSize.width() , coverSize.height() );
+    paint.drawRect( 0 , 0 , size.width() , size.height() );
 
     QTextDocument doc;
 
     QFont font = paint.font();
     font.setPixelSize( size.height() * 0.1 );
-    doc.setDefaultFont(font);
+    doc.setDefaultFont( font );
 
-    doc.setPageSize( QSize(size.width() - 2 * margin - coverSize.width() , size.height() - 2* margin));
-    doc.setHtml( title );
-
+    doc.setPageSize( QSize( size.width() - 2 * margin - coverSize.width() , size.height() - 2 * margin ) );
+    doc.setHtml( QString( "<font color=\"white\">%1</font>" ).arg( title ));
 
     paint.save();
-    paint.translate(coverSize.width() + 2 * margin ,  (size.height() - doc.size().height() )/ 2);
+    paint.translate( coverSize.width() + 2 * margin , ( size.height() - doc.size().height() ) / 2);
 
     doc.drawContents( &paint );
 

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -576,7 +576,7 @@ TomahawkWindow::updatePreview()
     QString title( "Tomahawk" );
     if ( !m_currentTrack.isNull() ) {
         cover = m_currentTrack->track()->albumPtr()->cover( coverSize , false );
-        title = tr( "%1<br><br><br><b>%2</b>", "track, artist name" ).arg( m_currentTrack->track()->track(), m_currentTrack->track()->artist() );
+        title = tr( "%1<br><br><b>%2</b>", "track, artist name" ).arg( m_currentTrack->track()->track(), m_currentTrack->track()->artist() );
     }
     if ( cover.isNull() ) {
         cover = TomahawkUtils::defaultPixmap( TomahawkUtils::DefaultAlbumCover , TomahawkUtils::Original, coverSize );

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -570,27 +570,40 @@ void
 TomahawkWindow::updatePreview()
 {
     const QSize size = QDesktopWidget().availableGeometry().size();
-    const QSize coverSize( size.height() * 0.75 , size.height() * 0.75 );
-
+    const qreal margin = size.height() * 0.05;
+    const QSize coverSize( size.height() - 2 * margin , size.height() - 2 * margin);
     QPixmap cover;
-    if ( !AudioEngine::instance()->currentTrack().isNull() ) {
-        cover = AudioEngine::instance()->currentTrack()->track()->albumPtr()->cover( coverSize , false );
+    QString title( "Tomahawk" );
+    if ( !m_currentTrack.isNull() ) {
+        cover = m_currentTrack->track()->albumPtr()->cover( coverSize , false );
+        title = tr( "%1<br><br><br><b>%2</b>", "artist name, track" ).arg( m_currentTrack->track()->artist(), m_currentTrack->track()->track() );
     }
     if ( cover.isNull() ) {
         cover = TomahawkUtils::defaultPixmap( TomahawkUtils::DefaultAlbumCover , TomahawkUtils::Original, coverSize );
     }
 
     QPixmap thumb( size );
-    thumb.fill( Qt::white );
+    thumb.fill( QColor("#FF004C") );
 
     QPainter paint(&thumb);
-    paint.drawPixmap((size.width() - coverSize.width()) / 2 ,0, coverSize.width(), coverSize.height(), cover);
+    paint.drawPixmap(margin , margin, coverSize.width(), coverSize.height(), cover);
+
+    QTextDocument doc;
 
     QFont font = paint.font();
     font.setPixelSize( size.height() * 0.1 );
-    paint.setFont( font );
-    paint.setPen( Qt::black );
-    paint.drawText( QRect( 0 , coverSize.height() , size.width() , size.height() - coverSize.height() ) , windowTitle() , QTextOption( Qt::AlignCenter ) );
+    doc.setDefaultFont(font);
+
+    doc.setPageSize( QSize(size.width() - 2 * margin - coverSize.width() , size.height() - 2* margin));
+    doc.setHtml( title );
+
+
+    paint.save();
+    paint.translate(coverSize.width() + 2 * margin ,  (size.height() - doc.size().height() )/ 2);
+
+    doc.drawContents( &paint );
+
+    paint.restore();
 
     m_taskbarList->setIconicThumbnailPixmap( thumb );
     m_taskbarList->setIconicLivePreviewPixmap( thumb );

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -603,7 +603,7 @@ TomahawkWindow::updatePreview()
     doc.setDefaultFont( font );
 
     doc.setPageSize( QSize( size.width() - 2 * margin - coverSize.width() , size.height() - 2 * margin ) );
-    doc.setHtml( QString( "<font color=\"white\">%1</font>" ).arg( title ));
+    doc.setHtml( QString( "<center><font color=\"white\">%1</font></center>" ).arg( title ));
 
     paint.save();
     paint.translate( coverSize.width() + 2 * margin , ( size.height() - doc.size().height() ) / 2);

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -573,7 +573,7 @@ TomahawkWindow::updatePreview()
     const qreal margin = size.height() * 0.05;
     const QSize coverSize( size.height() - 2 * margin , size.height() - 2 * margin);
     QPixmap cover;
-    QString title( "Tomahawk" );
+    QString title( qApp->applicationName() );
     if ( !m_currentTrack.isNull() ) {
         cover = m_currentTrack->track()->albumPtr()->cover( coverSize , false );
         title = tr( "%1<br><br><b>%2</b>", "track, artist name" ).arg( m_currentTrack->track()->track(), m_currentTrack->track()->artist() );

--- a/src/tomahawk/TomahawkWindow.cpp
+++ b/src/tomahawk/TomahawkWindow.cpp
@@ -111,10 +111,6 @@ using namespace Accounts;
 TomahawkWindow::TomahawkWindow( QWidget* parent )
     : QMainWindow( parent )
     , TomahawkUtils::DpiScaler( this )
-    #if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-    , m_buttonCreatedID( RegisterWindowMessage( L"TaskbarButtonCreated" ) )
-    , m_taskbarList( 0 )
-    #endif
     , ui( new Ui::TomahawkWindow )
     , m_searchWidget( 0 )
     , m_trayIcon( 0 )
@@ -154,9 +150,7 @@ TomahawkWindow::TomahawkWindow( QWidget* parent )
 
 #ifdef Q_OS_WIN
     connect( AudioEngine::instance(), SIGNAL( stateChanged( AudioState, AudioState ) ), SLOT( audioStateChanged( AudioState, AudioState ) ) );
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 2, 0 )
     setupWindowsButtons();
-#endif
 #endif
 
     if ( qApp->arguments().contains( "--debug" ) )
@@ -537,59 +531,9 @@ TomahawkWindow::setupUpdateCheck()
 
 
 #ifdef Q_OS_WIN
-bool
+void
 TomahawkWindow::setupWindowsButtons()
 {
-#if QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-    const GUID IID_ITaskbarList3 = { 0xea1afb91,0x9e28,0x4b86, { 0x90,0xe9,0x9e,0x9f,0x8a,0x5e,0xef,0xaf } };
-    HRESULT hr = S_OK;
-
-    THUMBBUTTONMASK dwMask = THUMBBUTTONMASK( THB_ICON | THB_TOOLTIP | THB_FLAGS );
-    m_thumbButtons[TP_PREVIOUS].dwMask = dwMask;
-    m_thumbButtons[TP_PREVIOUS].iId = TP_PREVIOUS;
-    m_thumbButtons[TP_PREVIOUS].hIcon = thumbIcon(TomahawkUtils::PrevButton);
-    m_thumbButtons[TP_PREVIOUS].dwFlags = THBF_ENABLED;
-    m_thumbButtons[TP_PREVIOUS].szTip[ tr( "Back" ).toWCharArray( m_thumbButtons[TP_PREVIOUS].szTip ) ] = 0;
-
-    m_thumbButtons[TP_PLAY_PAUSE].dwMask = dwMask;
-    m_thumbButtons[TP_PLAY_PAUSE].iId = TP_PLAY_PAUSE;
-    m_thumbButtons[TP_PLAY_PAUSE].hIcon = thumbIcon(TomahawkUtils::PlayButton);
-    m_thumbButtons[TP_PLAY_PAUSE].dwFlags = THBF_ENABLED;
-    m_thumbButtons[TP_PLAY_PAUSE].szTip[ tr( "Play" ).toWCharArray( m_thumbButtons[TP_PLAY_PAUSE].szTip ) ] = 0;
-
-    m_thumbButtons[TP_NEXT].dwMask = dwMask;
-    m_thumbButtons[TP_NEXT].iId = TP_NEXT;
-    m_thumbButtons[TP_NEXT].hIcon = thumbIcon(TomahawkUtils::NextButton);
-    m_thumbButtons[TP_NEXT].dwFlags = THBF_ENABLED;
-    m_thumbButtons[TP_NEXT].szTip[ tr( "Next" ).toWCharArray( m_thumbButtons[TP_NEXT].szTip ) ] = 0;
-
-    m_thumbButtons[3].dwMask = dwMask;
-    m_thumbButtons[3].iId = -1;
-    m_thumbButtons[3].hIcon = 0;
-    m_thumbButtons[3].dwFlags = THBF_NOBACKGROUND | THBF_DISABLED;
-    m_thumbButtons[3].szTip[0] = 0;
-
-    m_thumbButtons[TP_LOVE].dwMask = dwMask;
-    m_thumbButtons[TP_LOVE].iId = TP_LOVE;
-    m_thumbButtons[TP_LOVE].hIcon = thumbIcon(TomahawkUtils::NotLoved);
-    m_thumbButtons[TP_LOVE].dwFlags = THBF_DISABLED;
-    m_thumbButtons[TP_LOVE].szTip[ tr( "Love" ).toWCharArray( m_thumbButtons[TP_LOVE].szTip ) ] = 0;
-
-    if ( S_OK == CoCreateInstance( CLSID_TaskbarList, NULL, CLSCTX_INPROC_SERVER, IID_ITaskbarList3, (void **)&m_taskbarList ) )
-    {
-        hr = m_taskbarList->HrInit();
-        if ( SUCCEEDED( hr ) )
-        {
-            hr = m_taskbarList->ThumbBarAddButtons( (HWND)winId(), ARRAYSIZE( m_thumbButtons ), m_thumbButtons );
-        }
-        else
-        {
-            m_taskbarList->Release();
-            m_taskbarList = 0;
-        }
-    }
-    return SUCCEEDED( hr );
-#else
     m_taskbarList = new QWinThumbnailToolBar( this );
     m_taskbarList->setWindow( this->windowHandle() );
 
@@ -625,34 +569,13 @@ TomahawkWindow::setupWindowsButtons()
     love->setInteractive( false );
     connect( love , SIGNAL( clicked() ) , this , SLOT( toggleLoved() ) );
     m_taskbarList->addButton(love);
-
-    return true;
-#endif//QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
 }
-
-
-#if QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-HICON
-TomahawkWindow::thumbIcon( TomahawkUtils::ImageType type )
-{
-    static QMap<TomahawkUtils::ImageType,HICON> thumbIcons;
-    if ( !thumbIcons.contains( type ) )
-    {
-        QPixmap pix ( TomahawkUtils::defaultPixmap(type , TomahawkUtils::Original, QSize( 40, 40 ) ) );
-        thumbIcons[type] = pix.toWinHICON();
-    }
-    return thumbIcons[type];
-}
-
-#else
 
 QIcon
 TomahawkWindow::thumbIcon(TomahawkUtils::ImageType type)
 {
     return  TomahawkUtils::defaultPixmap( type , TomahawkUtils::Original, QSize( 40, 40 ) );
 }
-
-#endif//QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
 
 #endif
 
@@ -844,99 +767,12 @@ TomahawkWindow::keyPressEvent( QKeyEvent* e )
     QMainWindow::keyPressEvent( e );
 }
 
-
-#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-bool
-TomahawkWindow::winEvent( MSG* msg, long* result )
-{
-    Q_UNUSED(result);
-#define TB_PRESSED Q_FUNC_INFO << "Taskbar Button Pressed:"
-
-    switch ( msg->message )
-    {
-    case WM_COMMAND:
-        if ( HIWORD( msg->wParam ) == THBN_CLICKED )
-        {
-            switch ( TB_STATES( LOWORD( msg->wParam ) ) )
-            {
-            case TP_PREVIOUS:
-                tLog() << TB_PRESSED << "Previous";
-                AudioEngine::instance()->previous();
-                break;
-            case TP_PLAY_PAUSE:
-                tLog() << TB_PRESSED << "Play/Pause";
-                AudioEngine::instance()->playPause();
-                break;
-            case TP_NEXT:
-                tLog() << TB_PRESSED << "Next";
-                AudioEngine::instance()->next();
-                break;
-            case TP_LOVE:
-                tLog() << TB_PRESSED << "Love";
-                toggleLoved();
-                break;
-            }
-            return true;
-        }
-        break;
-    }
-
-    if ( msg->message == m_buttonCreatedID )
-        return setupWindowsButtons();
-
-    return false;
-}
-#endif//defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-
-
 void
 TomahawkWindow::audioStateChanged( AudioState newState, AudioState oldState )
 {
     Q_UNUSED(oldState);
 #ifndef Q_OS_WIN
     Q_UNUSED(newState);
-#else
-#if QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-    if ( m_taskbarList == 0 )
-        return;
-    switch ( newState )
-    {
-    case AudioEngine::Playing:
-    {
-        m_thumbButtons[TP_PLAY_PAUSE].hIcon = thumbIcon(TomahawkUtils::PauseButton);
-        m_thumbButtons[TP_PLAY_PAUSE].szTip[ tr( "Pause" ).toWCharArray( m_thumbButtons[TP_PLAY_PAUSE].szTip ) ] = 0;
-        updateWindowsLoveButton();
-
-    }
-        break;
-
-    case AudioEngine::Paused:
-    {
-        m_thumbButtons[TP_PLAY_PAUSE].hIcon = thumbIcon(TomahawkUtils::PlayButton);
-        m_thumbButtons[TP_PLAY_PAUSE].szTip[ tr( "Play" ).toWCharArray( m_thumbButtons[TP_PLAY_PAUSE].szTip ) ] = 0;
-    }
-        break;
-
-    case AudioEngine::Stopped:
-    {
-        if ( !AudioEngine::instance()->currentTrack().isNull() )
-        {
-            disconnect( AudioEngine::instance()->currentTrack()->track().data(), SIGNAL( socialActionsLoaded() ), this, SLOT( updateWindowsLoveButton() ) );
-        }
-
-        m_thumbButtons[TP_PLAY_PAUSE].hIcon = thumbIcon(TomahawkUtils::PlayButton);
-        m_thumbButtons[TP_PLAY_PAUSE].szTip[ tr( "Play" ).toWCharArray( m_thumbButtons[TP_PLAY_PAUSE].szTip ) ] = 0;
-
-        m_thumbButtons[TP_LOVE].hIcon = thumbIcon(TomahawkUtils::NotLoved);
-        m_thumbButtons[TP_LOVE].dwFlags = THBF_DISABLED;
-    }
-        break;
-
-    default:
-        return;
-    }
-
-    m_taskbarList->ThumbBarUpdateButtons( (HWND)winId(), ARRAYSIZE( m_thumbButtons ), m_thumbButtons );
 #else
     QWinThumbnailToolButton *play = m_taskbarList->buttons()[ TP_PLAY_PAUSE ];
     switch ( newState )
@@ -976,7 +812,6 @@ TomahawkWindow::audioStateChanged( AudioState newState, AudioState oldState )
     default:
         return;
     }
-#endif//QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
 #endif//Q_OS_WIN
 }
 
@@ -984,23 +819,7 @@ TomahawkWindow::audioStateChanged( AudioState newState, AudioState oldState )
 void
 TomahawkWindow::updateWindowsLoveButton()
 {
-#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-    if ( m_taskbarList == 0 )
-        return;
-    if ( !AudioEngine::instance()->currentTrack().isNull() && AudioEngine::instance()->currentTrack()->track()->loved() )
-    {
-        m_thumbButtons[TP_LOVE].hIcon = thumbIcon(TomahawkUtils::Loved);
-        m_thumbButtons[TP_LOVE].szTip[ tr( "Unlove" ).toWCharArray( m_thumbButtons[TP_LOVE].szTip ) ] = 0;
-    }
-    else
-    {
-        m_thumbButtons[TP_LOVE].hIcon = thumbIcon(TomahawkUtils::NotLoved);
-        m_thumbButtons[TP_LOVE].szTip[ tr( "Love" ).toWCharArray( m_thumbButtons[TP_LOVE].szTip ) ] = 0;
-    }
-
-    m_thumbButtons[TP_LOVE].dwFlags = THBF_ENABLED;
-    m_taskbarList->ThumbBarUpdateButtons( (HWND)winId(), ARRAYSIZE( m_thumbButtons ), m_thumbButtons );
-#elif defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
     QWinThumbnailToolButton *love = m_taskbarList->buttons()[ TP_LOVE ];
 
     if ( !AudioEngine::instance()->currentTrack().isNull() )
@@ -1023,7 +842,7 @@ TomahawkWindow::updateWindowsLoveButton()
         love->setIcon( thumbIcon(TomahawkUtils::NotLoved) );
         love->setToolTip( tr( "Love" ) );
     }
-#endif//defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
+#endif//defined(Q_OS_WIN)
 }
 
 

--- a/src/tomahawk/TomahawkWindow.h
+++ b/src/tomahawk/TomahawkWindow.h
@@ -149,7 +149,11 @@ private slots:
     void toggleLoved();
 
     void audioStateChanged( AudioState newState, AudioState oldState );
+    
+#ifdef Q_OS_WIN
     void updateWindowsLoveButton();
+    void updatePreview();
+#endif
 
 private:
     void loadSettings();

--- a/src/tomahawk/TomahawkWindow.h
+++ b/src/tomahawk/TomahawkWindow.h
@@ -37,10 +37,8 @@
 #include <QToolButton>
 #ifdef Q_OS_WIN
     #include <shobjidl.h>
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 2, 0 )
     #include <QWinThumbnailToolBar>
     #include <QWinThumbnailToolButton>
-#endif
 #endif
 
 namespace Tomahawk
@@ -91,10 +89,6 @@ protected:
     void keyPressEvent( QKeyEvent* e );
 
     bool eventFilter( QObject* obj, QEvent* event );
-
-#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-    bool winEvent( MSG* message, long* result );
-#endif
 
 public slots:
     void createStation();
@@ -173,16 +167,9 @@ private:
     void importPlaylist( const QString& url, bool autoUpdate );
 
 #ifdef Q_OS_WIN
-    bool setupWindowsButtons();
-#if QT_VERSION < QT_VERSION_CHECK( 5, 2, 0 )
-    const unsigned int m_buttonCreatedID;
-    HICON thumbIcon(TomahawkUtils::ImageType type);
-    ITaskbarList3* m_taskbarList;
-    THUMBBUTTON m_thumbButtons[5];
-#else
+    void setupWindowsButtons();
     QIcon thumbIcon(TomahawkUtils::ImageType type);
     QWinThumbnailToolBar *m_taskbarList;
-#endif
     enum TB_STATES{ TP_PREVIOUS = 0,TP_PLAY_PAUSE = 1,TP_NEXT = 2, TP_SPACE = 3, TP_LOVE = 4 };
 #endif
 


### PR DESCRIPTION
Proof of concept of using the api provided by QtWindowsExtras to use the album art as window preview.

# Current preview
## Thumb bar
<img width="960" alt="Current preview" src="https://cloud.githubusercontent.com/assets/200626/10881964/5be23e72-8167-11e5-9431-a4865a8420d8.PNG">

# Album art
## Thumb bar
![2015-11-02](https://cloud.githubusercontent.com/assets/200626/10881942/30c27d92-8167-11e5-9f16-829e5602fb11.png)
## App switcher (alt+window / alt+tab)
![screenshot 3](https://cloud.githubusercontent.com/assets/200626/10881943/30c291a6-8167-11e5-87f5-b5aee37a6916.png)


Is this wanted?
How should the preview look like? Design idea and measurement's needed.