### PR TITLE
Improve track matching with non-alphanum character differences

### DIFF
--- a/src/libtomahawk/Query.cpp
+++ b/src/libtomahawk/Query.cpp
@@ -636,6 +636,11 @@ Query::howSimilar( const Tomahawk::result_ptr& r )
         qTrackname  = queryTrack()->trackSortname();
     }
 
+    //Cleanup symbols for minor naming differences
+    qArtistname.remove(QRegExp(QString::fromUtf8("[-`~!@#$%^&*()_—+=|:;<>«»,.?/{}\'\"\\[\\]\\\\]")));
+    qTrackname.remove(QRegExp(QString::fromUtf8("[-`~!@#$%^&*()_—+=|:;<>«»,.?/{}\'\"\\[\\]\\\\]")));
+    qAlbumname.remove(QRegExp(QString::fromUtf8("[-`~!@#$%^&*()_—+=|:;<>«»,.?/{}\'\"\\[\\]\\\\]")));
+
     // normal edit distance
     const int artdist = TomahawkUtils::levenshtein( qArtistname, rArtistname );
     const int trkdist = TomahawkUtils::levenshtein( qTrackname, rTrackname );


### PR DESCRIPTION
As example this allows "Wendigo Pt. 1 (Quest For Fire)" to resolve "Wendigo, Part 1: Quest for Fire"
(mentioned in #386 