### PR TITLE
Allow downloads from a non-collection resolver

### DIFF
--- a/data/js/tomahawk.js
+++ b/data/js/tomahawk.js
@@ -275,6 +275,9 @@ Tomahawk.Resolver = {
     getStreamUrl: function (params) {
         return params;
     },
+    getDownloadUrl: function (params) {
+        return params;
+    },
     resolve: function() {
     },
     _adapter_resolve: function (params) {
@@ -1769,6 +1772,14 @@ Tomahawk.Collection = {
     getStreamUrl: function(params) {
         if(this.resolver) {
           return this.resolver.getStreamUrl(params);
+        }
+
+        return params;
+    },
+
+    getDownloadUrl: function(params) {
+        if(this.resolver) {
+          return this.resolver.getDownloadUrl(params);
         }
 
         return params;

--- a/src/libtomahawk/DownloadJob.cpp
+++ b/src/libtomahawk/DownloadJob.cpp
@@ -206,22 +206,13 @@ DownloadJob::download()
 {
     if ( m_state == Running )
         return true;
+
     setState( Running );
 
-    if ( m_result->resolvedByCollection() )
-    {
-        Tomahawk::ScriptCollection* collection = qobject_cast<Tomahawk::ScriptCollection*>( m_result->resolvedByCollection().data() );
-        if ( collection )
-        {
-            QVariantMap arguments;
-            arguments[ "url" ] = m_format.url;
+    Tomahawk::ScriptJob *job = m_result->resolvedBy()->getDownloadUrl( m_result, m_format );
+    connect( job, SIGNAL( done(QVariantMap) ), SLOT( onUrlRetrieved(QVariantMap) ) );
+    job->start();
 
-            // HACK: *shrug* WIP.
-            Tomahawk::ScriptJob* job = collection->scriptObject()->invoke( "getStreamUrl", arguments );
-            connect( job, SIGNAL( done(QVariantMap) ), SLOT( onUrlRetrieved(QVariantMap) ) );
-            job->start();
-        }
-    }
     return true;
 }
 

--- a/src/libtomahawk/DownloadJob.cpp
+++ b/src/libtomahawk/DownloadJob.cpp
@@ -209,9 +209,13 @@ DownloadJob::download()
 
     setState( Running );
 
-    Tomahawk::ScriptJob *job = m_result->resolvedBy()->getDownloadUrl( m_result, m_format );
-    connect( job, SIGNAL( done(QVariantMap) ), SLOT( onUrlRetrieved(QVariantMap) ) );
-    job->start();
+    if (m_result->resolvedBy() != nullptr) {
+        Tomahawk::ScriptJob *job = m_result->resolvedBy()->getDownloadUrl( m_result, m_format );
+        connect( job, SIGNAL( done(QVariantMap) ), SLOT( onUrlRetrieved(QVariantMap) ) );
+        job->start();
+    } else {
+        onUrlRetrieved({{"url", m_format.url}});
+    }
 
     return true;
 }

--- a/src/libtomahawk/resolvers/JSResolver.cpp
+++ b/src/libtomahawk/resolvers/JSResolver.cpp
@@ -711,3 +711,14 @@ JSResolver::getStreamUrl( const result_ptr& result )
 
     return scriptObject()->invoke( "getStreamUrl", arguments );
 }
+
+ScriptJob*
+JSResolver::getDownloadUrl( const result_ptr& result, const DownloadFormat& format )
+{
+    QVariantMap arguments;
+    arguments["url"] = format.url.toString();
+    arguments["extension"] = format.extension;
+    arguments["mimetype"] = format.mimetype;
+
+    return scriptObject()->invoke( "getDownloadUrl", arguments );
+}

--- a/src/libtomahawk/resolvers/JSResolver.h
+++ b/src/libtomahawk/resolvers/JSResolver.h
@@ -76,6 +76,8 @@ public:
     ScriptAccount* scriptAccount() const;
 
     ScriptJob* getStreamUrl( const result_ptr& result ) override;
+    ScriptJob* getDownloadUrl( const result_ptr& result, const DownloadFormat &format ) override;
+
 
 public slots:
     void resolve( const Tomahawk::query_ptr& query ) override;

--- a/src/libtomahawk/resolvers/Resolver.cpp
+++ b/src/libtomahawk/resolvers/Resolver.cpp
@@ -45,3 +45,12 @@ Tomahawk::Resolver::getStreamUrl( const result_ptr& result )
 
     return new SyncScriptJob( data );
 }
+
+Tomahawk::ScriptJob*
+Tomahawk::Resolver::getDownloadUrl( const result_ptr& result, const DownloadFormat& format )
+{
+    QVariantMap data;
+    data[ "url" ] = format.url.toString();
+
+    return new SyncScriptJob( data );
+}

--- a/src/libtomahawk/resolvers/Resolver.h
+++ b/src/libtomahawk/resolvers/Resolver.h
@@ -21,6 +21,7 @@
 
 #include "Typedefs.h"
 #include "DllMacro.h"
+#include "../DownloadJob.h"
 
 #include <QObject>
 
@@ -52,6 +53,7 @@ public:
 
     virtual void resolve( const Tomahawk::query_ptr& query ) = 0;
     virtual ScriptJob* getStreamUrl( const result_ptr& result );
+    virtual ScriptJob* getDownloadUrl( const result_ptr& result, const DownloadFormat& format );
 };
 
 } //ns

--- a/src/libtomahawk/resolvers/ScriptCollection.cpp
+++ b/src/libtomahawk/resolvers/ScriptCollection.cpp
@@ -235,6 +235,16 @@ ScriptCollection::getStreamUrl( const result_ptr& result )
     return scriptObject()->invoke( "getStreamUrl", arguments );
 }
 
+ScriptJob*
+ScriptCollection::getDownloadUrl( const result_ptr& result, const DownloadFormat& format )
+{
+    QVariantMap arguments;
+    arguments["url"] = format.url.toString();
+    arguments["extension"] = format.extension;
+    arguments["mimetype"] = format.mimetype;
+
+    return scriptObject()->invoke( "getDownloadUrl", arguments );
+}
 
 void
 ScriptCollection::parseMetaData( const QVariantMap& metadata )

--- a/src/libtomahawk/resolvers/ScriptCollection.h
+++ b/src/libtomahawk/resolvers/ScriptCollection.h
@@ -96,6 +96,7 @@ public:
     unsigned int timeout() const override;
     void resolve( const Tomahawk::query_ptr& query ) override;
     ScriptJob* getStreamUrl( const result_ptr& result ) override;
+    ScriptJob* getDownloadUrl( const result_ptr& result, const DownloadFormat &format ) override;
 
 private slots:
     void onIconFetched();


### PR DESCRIPTION
I noticed downloads don't work when results come from a regular (non-collection) resolver, so here is a small fix for that.