### PR TITLE
OSX with dark menu and dock settings - light system tray icon

### DIFF
--- a/src/tomahawk/TomahawkTrayIcon.cpp
+++ b/src/tomahawk/TomahawkTrayIcon.cpp
@@ -43,6 +43,9 @@ TomahawkTrayIcon::TomahawkTrayIcon( QObject* parent )
 {
 #ifdef Q_OS_MAC
     QIcon icon( RESPATH "icons/tomahawk-grayscale-icon-128x128.png" );
+    #if QT_VERSION >= QT_VERSION_CHECK( 5, 6, 1 )
+        icon.setIsMask( true );
+    #endif
 #else
     QIcon icon( RESPATH "icons/tomahawk-icon-128x128.png" );
 #endif


### PR DESCRIPTION
If OSX is set to use a dark system menu and dock, it becomes hard to see the system tray icon (dark grey on black). Small tweak to enable the icon's colour to 'invert' in dark mode