### PR TITLE
Add Github Action for building on Linux

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,16 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: tomahawkmusicplayer/ubuntu:latest
+      env:
+        MIX_ENV: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Build and test
+        run: /usr/local/bin/build-and-test.sh


### PR DESCRIPTION
This Github Action workflow will build and test whenever there is a push to the repository. Currently only builds on Linux but I plan to add Windows and OSX support. 